### PR TITLE
libsdl2-cocoa: fix header issue that breaks build on Tiger

### DIFF
--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -65,6 +65,14 @@ build.args          V=1
 # Avoid broken clang. Xcode gcc works, as of 2.32.x at least.
 compiler.blacklist  *clang*
 
+platform darwin powerpc {
+    if {![catch {sysctl hw.vectorunit} result] && $result > 0} {
+        # Work around buggy header. https://trac.macports.org/ticket/55251
+        configure.cxxflags-append -faltivec
+        configure.cflags-append -faltivec
+    }
+}
+
 # Fix-ups for PowerPC systems:
 patchfiles-append   0001-Fixes-for-PowerPC.patch
 


### PR DESCRIPTION
I have tested this portfile and libsdl2-cocoa builds successfully on Tiger with it. Thank you for the fix! I thought it should perhaps be added to the portfile if it does not break anything on Leopard or Snow Leopard.