### PR TITLE
Amule: Change boost version so all dependencies can build on Tiger

### DIFF
--- a/net/amule/Portfile
+++ b/net/amule/Portfile
@@ -10,7 +10,7 @@ PortGroup           wxWidgets 1.0
 if {${os.platform} ne "darwin" || ${os.major} > 9} {
     boost.version   1.87
 } else {
-    boost.version   1.76
+    boost.version   1.78
 }
 
 github.setup        amule-project amule 9ceeaa68b9727fa38efd9ddcf774b20d39d5a200


### PR DESCRIPTION
Per kencu here: https://trac.macports.org/ticket/71753
and also my own testing, boost178 works on Tiger ppc while earlier boost versions do not. While this ticket is about boost171, I suspect that a similar issue afflicts boost176. I was able to build all dependencies for amule on ppc Tiger after this portfile change. Another option would be to fix a boost port and then use that, and I am happy to provide logs and testing, but I think it might be easier to use boost178 on Tiger when relevant. I would love to hear your opinion on which route makes sense, as you have far more experience than my less than three months with Macports. 