### PR TITLE
Gawk: Tiger fallback, omit patch

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -6,7 +6,7 @@ PortGroup               legacysupport 1.1
 
 name                    gawk
 version                 5.3.2
-revision                1
+revision                2
 categories              lang
 license                 GPL-3+
 installs_libs           no
@@ -26,7 +26,9 @@ checksums               rmd160  9686dbabcc6207d9948c66445333f5607dfee38d \
                         size    3749260
 
 # https://trac.macports.org/ticket/72587
-patchfiles              patch-_NSGetExecutablePath.diff
+if {${os.major} > 8} {
+    patchfiles              patch-_NSGetExecutablePath.diff
+}
 
 depends_build           port:gettext
 
@@ -49,6 +51,11 @@ platform darwin {
 
 # fix build on Tiger see https://trac.macports.org/ticket/55145
 platform darwin 8 {
+    version 5.3.1
+    checksums           rmd160  85a4a30cdde82519c21545c097aa45aee9ae3a63 \
+                        sha256  694db764812a6236423d4ff40ceb7b6c4c441301b72ad502bb5c27e00cd56f78 \
+                        size    3510032
+
     configure.cppflags-append \
                         -D__DARWIN_UNIX03
 }


### PR DESCRIPTION
Current gawk does not build on Tiger, even with the patch. This Portfile adding a fallback works. If you would prefer to see the log of build failure, I saved that on a Powerbook and I can provide it on the Macrumors forum. I doubt I can attach it here.
Let me know if there are any formatting improvements needed. About five ports fail to build and need a fallback in this repository that I have found so far (and more than twenty in the main Macports repository). I may end up doing quite a few more of these, so I would like to do them right.