### PR TITLE
new port: kobodl

### DIFF
--- a/net/kobodl/Portfile
+++ b/net/kobodl/Portfile
@@ -1,0 +1,34 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           python 1.0
+PortGroup           github 1.0
+
+github.setup        subdavis kobo-book-downloader 0.12.0
+
+name                kobodl
+version             0.12.0
+revision            0
+categories-prepend  net
+platforms           any
+license             Unlicense
+maintainers         nomaintainer
+description         Kobo ebook downloader
+long_description    {*}${description} and client.
+checksums           rmd160  d8110b066a755a70263b819aca7ee5f059257476 \
+                    sha256  8e47f088cbc6ecac03ee47d693717c577dc1a0de6745b240dd79cb5a9a9c1df9 \
+                    size    2478937
+supported_archs     noarch
+
+github.tarball_from archive
+
+python.default_version  312
+python.pep517_backend   poetry
+
+depends_lib-append  port:comicon \
+                    port:py${python.version}-beautifulsoup4 \
+                    port:py${python.version}-flask \
+                    port:py${python.version}-pycryptodome \
+                    port:py${python.version}-requests \
+                    port:py${python.version}-setuptools \
+                    port:py${python.version}-tabulate


### PR DESCRIPTION
Allows access to Kobo, which is broken in Aquafox. Comes with web GUI that is confirmed working in Aquafox.