### PR TITLE
mpv-legacy: fix build on Tiger

### DIFF
--- a/multimedia/mpv-legacy/Portfile
+++ b/multimedia/mpv-legacy/Portfile
@@ -277,8 +277,11 @@ platform darwin {
             set sdks [glob -directory ${sdks_dir} MacOSX*.sdk]
             configure.sdkroot [lindex [lsort -command vercmp ${sdks}] end]
         }
-        if {${configure.sdkroot} ne ""} {
+        if {${configure.sdkroot} ne "" && ${os.major} > 8} {
             configure.sdk_version [exec /usr/libexec/PlistBuddy -c Print:ProductVersion ${configure.sdkroot}/System/Library/CoreServices/SystemVersion.plist]
+        }
+        if {${os.major} == 8} {
+            configure.sdk_version 10.4
         }
         if {[llength [split ${configure.sdk_version} .]] < 2} {
             configure.sdk_version ${configure.sdk_version}.0


### PR DESCRIPTION
With the +tigerrpath variant on ld64-97, building older versions of mpv is now possible on Tiger. Unfortunately, the .plist way of identifying the right SDK to use doesn't work on Tiger. Once the 10.4 SDK is correctly targeted, mpv-legacy build fine on Tiger.
It even sort of works (colors are sometimes off, audio sometimes doesn't stream over the internet, other wacky minor issues).
Since it is a simple fix, I thought I would make a PR for it before I forget how I did it.