### PR TITLE
libass: Fix build on Tiger

### DIFF
--- a/multimedia/libass/Portfile
+++ b/multimedia/libass/Portfile
@@ -55,6 +55,10 @@ configure.args  --disable-silent-rules \
 # ass.h:421: error: wrong number of arguments specified for 'deprecated' attribute
 compiler.blacklist-append   {*gcc-[34].*}
 
+platform darwin 8 {
+    configure.cflags-append -Wno-error=incompatible-pointer-types
+}
+
 if {${universal_possible} && [variant_isset universal]} {
     # Needed by configure to correctly set the yasm build flags.
     set merger_host(arm64)  "aarch64-apple-${os.platform}${os.major}.${os.minor}.0"


### PR DESCRIPTION
Tiger errors over an incompatible pointer type, adding a configure option to prevent the error allows it to build on Tiger. Curious if there is a better solution.