### PR TITLE
libxmlb: Fix build on Tiger

### DIFF
--- a/devel/libxmlb/Portfile
+++ b/devel/libxmlb/Portfile
@@ -31,6 +31,13 @@ depends_lib-append  path:lib/pkgconfig/glib-2.0.pc:glib2 \
 compiler.blacklist-append \
                     *gcc-4.0 *gcc-4.2 {clang < 700}
 
+# fix :info:build Undefined symbols:
+# :info:build   "___stack_chk_fail",
+# with a solution from https://trac.macports.org/ticket/63469 on Tiger
+platform darwin 8 {
+    configure.ldflags-append -lssp
+}
+
 configure.args-append \
                     -Dcli=true \
                     -Dgtkdoc=false \


### PR DESCRIPTION
I ran into a similar error to what was described in this ticket: https://trac.macports.org/ticket/63469 And one of the solutions suggested in that thread works easily.
The same solution also fixes libadwaita. Some different ones are needed for appstream, like adding the legacysupport portgroup. After my fixes to all three, Komikku functions, but is slow on a single processor G4.
Since libxmlb is the only port currently in powerpc ports, it is the only fix I am submitting for now.