### PR TITLE
mldonkey: fix build on Tiger

### DIFF
--- a/net/mldonkey/Portfile
+++ b/net/mldonkey/Portfile
@@ -73,6 +73,10 @@ compiler.blacklist-append \
 configure.cxxflags-append \
                     -std=c++98
 
+platform darwin 8 {
+    configure.cflags-append -Wno-error=incompatible-pointer-types
+}
+
 configure.args-append \
                     --enable-multinet \
                     --enable-upnp-natpmp \


### PR DESCRIPTION
The 'const char **' error is common on Tiger.  An example with the solution I borrowed can be found here: https://trac.macports.org/ticket/71658 I can present the failed log if you think that might lead to a better solution, but mldonkey is working fine for me. Web GUI launches and is navigable. I don't know enough about these types of programs to know if all functionality is there.