### PR TITLE
ocaml-dune: add Tiger fallback

### DIFF
--- a/ocaml/ocaml-dune/Portfile
+++ b/ocaml/ocaml-dune/Portfile
@@ -3,6 +3,8 @@
 PortSystem          1.0
 PortGroup           github 1.0
 PortGroup           ocaml 1.1
+PortGroup           legacysupport 1.1
+legacysupport.newest_darwin_requires_legacy 8
 
 name                ocaml-dune
 github.setup        ocaml dune 3.20.2
@@ -59,16 +61,13 @@ patchfiles-append       patch-fix-3.20.diff
 
 # add fallback for Tiger that does not need libproc.h
 platform darwin 8 {
-    PortGroup           legacysupport 1.1
-
     name                ocaml-dune
     github.setup        ocaml dune 0d98de1cd607e99ae099e5c23482443d22570fbb
-    revision            1
 
     checksums           rmd160  7c086368485084f4a2d1521b7359f939306bca38 \
                         sha256  a4a6a4bbf422b4ee1baef3182576ab3eb64deded49a858ae83656916b0faa57c \
                         size    1777067
-github.tarball_from archive
+    github.tarball_from archive
 
     depends_build-append port:gmake
     build.cmd ${prefix}/bin/gmake


### PR DESCRIPTION
As suggested in the other PR, I am adding a fallback from the commit right before #include libproc.h gets added.