### PR TITLE
opam: add Tiger fallback

### DIFF
--- a/ocaml/opam/Portfile
+++ b/ocaml/opam/Portfile
@@ -82,4 +82,15 @@ platform darwin {
         build.env-append \
                     DUNE_CONFIG__COPY_FILE=portable
     }
+
+    # 2.3 is the last version that works with the version of dune that doesn't use libproc.h
+    if {${os.major} < 9} {
+        github.setup        ocaml opam-full 2.3.0
+        revision            0
+        checksums           rmd160  af863ac8afccbdd3e825e3fe1fffcdf66d128993 \
+                            sha256  506ba76865dc315b67df9aa89e7abd5c1a897a7f0a92d7b2694974fdc532b346 \
+                            size    12860518
+        depends_build-append port:gmake
+        build.cmd ${prefix}/bin/gmake
+    }
 }


### PR DESCRIPTION
2.3 appears to be the last version that works with the dune that doesn't use libproc.h