### PR TITLE
audacious-core: fix build on Tiger

### DIFF
--- a/audio/audacious-core/Portfile
+++ b/audio/audacious-core/Portfile
@@ -59,6 +59,11 @@ configure.args      -Ddbus=true \
 depends_build-append \
                     path:bin/pkg-config:pkgconfig
 
+#fix invalid conversion from 'char**' to 'const char**'
+platform darwin 8 {
+    configure.cxxflags-append -fpermissive
+}
+
 post-destroot {
     xinstall -d -m 0755 ${destroot}${prefix}/share/doc/${real_name}
     move ${destroot}${prefix}/share/${real_name}/AUTHORS \


### PR DESCRIPTION
Another port that needs -fpermissive to build.