### PR TITLE
abiword-x11: fix Tiger build by building without boost

### DIFF
--- a/editors/abiword-x11/Portfile
+++ b/editors/abiword-x11/Portfile
@@ -92,6 +92,12 @@ configure.args      --disable-default-plugins \
                     --with-champlain=no \
                     --without-evolution-data-server
 
+#switch boost dependency to one known to build on Tiger, then build without boost
+platform darwin 8 {
+    boost.version   1.78
+    configure.args-replace --with-boost=[boost::install_area] --without-boost
+}
+
 variant evolution description "Enable Evolution data server" {
     depends_lib-append \
                     port:evolution-data-server


### PR DESCRIPTION
If there is a way to not require boost at all, that would be even better. Failing that, I have tested this and it build.