### PR TITLE
celluloid: fix build on Tiger

### DIFF
--- a/gnome/celluloid/Portfile
+++ b/gnome/celluloid/Portfile
@@ -58,9 +58,6 @@ depends_lib-append  port:desktop-file-utils \
 require_active_variants mpv libmpv
 
 platform darwin 8 {
-    depends_lib-delete port:mpv
-    depends_lib-append port:mpv-legacy
-
     configure.ldflags-append -lssp
 }
 


### PR DESCRIPTION
Not sure if you would prefer to make mpv-legacy available as a backend on all platforms.