### PR TITLE
libunibreak: new port in devel

### DIFF
--- a/devel/libunibreak/Portfile
+++ b/devel/libunibreak/Portfile
@@ -1,29 +1,26 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*-
 # vim: set fileencoding=utf-8 tabstop=8 shiftwidth=4 softtabstop=4 noexpandtab filetype=tcl :
 
-PortSystem	    1.0
+PortSystem      1.0
 
-name		    libunibreak
-version		    3.0
-revision	    0
-conflicts           liblinebreak
-platforms	    darwin
-categories	    devel
-maintainers	    nomaintainer
-description	    Unicode linebreak library
-long_description								    \
-    libunibreak, an implementation of the line breaking algorithm as described	    \
-    in Unicode 5.2.0 Standard Annex 14, Revision 24, available at		    \
+name            libunibreak
+version         3.0
+revision        0
+conflicts       liblinebreak
+categories      devel
+maintainers     nomaintainer
+description     Unicode linebreak library
+long_description \
+    ${name}, an implementation of the line breaking algorithm as described \
+    in Unicode 5.2.0 Standard Annex 14, Revision 24, available at \
     http://www.unicode.org/reports/tr14/tr14-24.html
 
-homepage	    http://vimgadgets.sourceforge.net/
-master_sites	    sourceforge:vimgadgets
-use_parallel_build  no
-universal_variant   no
+homepage            https://vimgadgets.sourceforge.net
+master_sites        sourceforge:vimgadgets
 
-checksums           md5     13e9a325c00b5943d6afb21f028635e6 \
-                    sha1    8a506e4197258caa2c9a7b6cd3cabc5b6672d7c0 \
-                    rmd160  4ac95004e6657a4216bcd991905c5c9eb26defe9 \
+checksums           rmd160  4ac95004e6657a4216bcd991905c5c9eb26defe9 \
                     sha256  4b88c85a4568a7b88aa748c2aa15c52e0ae8a8c1107ead3ed6846e6121d6ea29 \
                     size    797361
 
+use_parallel_build  no
+universal_variant   no


### PR DESCRIPTION
libunibreak is a newer version of https://ports.macports.org/port/liblinebreak
Presumably Macports never updated this because of the name change and the paucity of programs needing this library.
However, at least one program needs the newer version named libunibreak.