### PR TITLE
PortGroup boost-1.0.tcl: Move to 1.76 for Tiger and Leopard

### DIFF
--- a/_resources/port1.0/group/boost-1.0.tcl
+++ b/_resources/port1.0/group/boost-1.0.tcl
@@ -28,10 +28,7 @@ default boost_cache_env_vars      ""
 
 proc boost::default_version {} {
     global os.platform os.major
-    # Pin version on Darwin9 and older to pre-c++11 version (1.71)
-    if { ${os.platform} eq "darwin" && ${os.major} == 9 } {
-        return 1.71
-    } else {
+    if { ${os.platform} eq "darwin"} {
         return 1.76
     }
 }


### PR DESCRIPTION
Since boost176 (and boost181, I did test it) now works on Tiger, and boost171 still doesn't, could we move to boost176 as the default? If Leopard can build boost176, perhaps all powerpc-ports could move to boost portgroup being a stub for boost176 instead of boost171.