### PR TITLE
pithos: new port in audio

### DIFF
--- a/audio/pithos/Portfile
+++ b/audio/pithos/Portfile
@@ -4,8 +4,6 @@ PortSystem                  1.0
 PortGroup                   github 1.0
 PortGroup                   meson 1.0
 
-name                        pithos
-version                     1.6.2
 github.setup                pithos pithos 1.6.2
 github.tarball_from         archive
 distname                    ${github.version}
@@ -14,7 +12,7 @@ checksums                   rmd160  841c7d87f8cd93a4092adde0103945190403858a \
                             size    122622
 
 categories                  audio
-maintainers                 nomaintainer
+maintainers                 ForestExpertise
 license                     GPL
 
 description                 GTK-based pandora.com player
@@ -28,9 +26,9 @@ set py_ver                  311
 depends_build               port:appstream-glib
 
 depends_lib-append          port:gnome-keyring \
-                            port:gobject-introspection \
+                            path:lib/pkgconfig/gobject-introspection-1.0.pc:gobject-introspection \
                             port:gstreamer1-gst-libav \
-                            port:gtk3 \
+                            path:lib/pkgconfig/gtk+-3.0.pc:gtk3 \
                             port:libsecret \
                             port:py${py_ver}-gobject3
 


### PR DESCRIPTION
A Pandora client that was a selling point for PowerPC Linux (https://forums.macrumors.com/search/5312591/?q=pithos&t=post&c[child_nodes]=1&c[nodes][0]=145&o=relevance) Now working on Mac OS!
To my knowledge, this will be the only GUI client for Pandora on PowerPC Macs. And hopefully I did a better job on formatting than on my other new port submissions.