### PR TITLE
libdom: Fix build on Tiger with gmake

### DIFF
--- a/devel/libdom/Portfile
+++ b/devel/libdom/Portfile
@@ -32,6 +32,11 @@ build.args          NSSHARED=${prefix}/share/netsurf-buildsystem \
 destroot.args       NSSHARED=${prefix}/share/netsurf-buildsystem \
                     PREFIX=${destroot}${prefix}
 
+platform darwin 8 {
+    depends_build-append port:gmake
+    build.cmd ${prefix}/bin/gmake
+}
+
 build {
     system -W ${worksrcpath} "LDFLAGS=\"${configure.ldflags}\" ${build.cmd} ${build.args} COMPONENT_TYPE=lib-shared"
 }


### PR DESCRIPTION
If it were this easy to fix all ports, Tiger would have parity with later Mac OS in no time. To be fair, it is this easy close to half the time.