### PR TITLE
elinks-devel: fix build on Tiger

### DIFF
--- a/www/elinks-devel/Portfile
+++ b/www/elinks-devel/Portfile
@@ -119,8 +119,9 @@ compiler.cxx_standard       2017
 
 # avoid execinfo.h
 platform darwin 8 {
-    configure.args-delete   -Dbacktrace=true
-    configure.args-append   -Dbacktrace=false
+    configure.args-replace \
+                    -Dbacktrace=true \
+                    -Dbacktrace=false
 }
 
 variant colors description "Enable support for 88/256 colors and True color" {


### PR DESCRIPTION
execinfo.h does not exist on Tiger. Disabling backtrace keeps it from being included and causing a build failure.