### PR TITLE
glib2: Fix compiler usage on Tiger

### DIFF
--- a/devel/glib2/Portfile
+++ b/devel/glib2/Portfile
@@ -102,7 +102,9 @@ compiler.blacklist-append   gcc-3.3 *gcc-4.0 *gcc-4.2
 platform darwin {
     if {${os.major} <= 8} {
         # https://trac.macports.org/ticket/71658
-        compiler.whitelist-append macports-gcc-10
+        configure.cflags-append \
+            -Wno-error=incompatible-pointer-types \
+            -Wno-error=format
     }
 }
 


### PR DESCRIPTION
Since compiler blacklist wasn't working sensibly (it tried to require libcxx-powerpc and gcc13), I propose switching to whitelisting the compiler that actually is confirmed to build glib2 on Tiger
P.s. Did you have the chance to look at my changes on SDL3?