### PR TITLE
gcc14: require flex on Tiger to fix build

### DIFF
--- a/lang/gcc14/Portfile
+++ b/lang/gcc14/Portfile
@@ -66,7 +66,6 @@ depends_run-append  port:gcc_select \
 # Notice, that gcc needs a functional flex. Normally it is present in system prefix.
 # On 10.6.8 on powerpc, however, make sure that /usr/bin/flex has a ppc slice.
 # Otherwise the build fails, and activating flex port to resume it will not help.
-# On 10.4.11 on PowerPC, you will need to install the flex port before building.
 # If you face a flex-related error, make sure to install the right flex,
 # then run port clean and build again.
 
@@ -224,6 +223,9 @@ if {${os.platform} eq "darwin"} {
     patchfiles-append      darwin-ppc-fpu.patch
 
     if {${os.major} == 8} {
+        depends_build-append \
+                           port:flex
+
         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117834
         patchfiles-append darwin8-define-PTHREAD_RWLOCK_INITIALIZER.patch
 


### PR DESCRIPTION
I had an unpleasant flex related failure on Tiger that costed 25 hours of compilation time. Building with flex installed and active allowed libgcc14 to install fine.
I am unsure if it would be better to add flex as a build dependency for 10.4.11 and/or 10.6.8. I defer to your judgement on that