### PR TITLE
libheif: remove optional vvdec dependency on Tiger

### DIFF
--- a/multimedia/libheif/Portfile
+++ b/multimedia/libheif/Portfile
@@ -72,6 +72,11 @@ configure.args-append       -DWITH_AOM_DECODER:BOOL=ON \
                             -DWITH_VVENC:BOOL=OFF \
                             -DWITH_X265:BOOL=ON
 
+platform darwin 8 {
+    depends_lib-delete      port:vvdec
+    configure.args-replace  -DWITH_VVDEC:BOOL=ON -DWITH_VVDEC:BOOL=OFF
+}
+
 # Disable dynamic plugin loading, due to upstream issue:
 #   clang: error: invalid argument '-compatibility_version 1.0.0' only allowed with '-dynamiclib'
 # We don't lose any functionality though, as we're building with everything enabled as built-ins.


### PR DESCRIPTION
Vvdec does not build on Tiger due to usage of posix_memalign Since this is the only port that depends on it, and vvdec is optional for libheif, it is simplest to remove it.