### PR TITLE
chafa: fix build on Tiger by suppressing warning

### DIFF
--- a/graphics/chafa/Portfile
+++ b/graphics/chafa/Portfile
@@ -48,3 +48,7 @@ use_xz              yes
 # https://trac.macports.org/ticket/66729
 compiler.blacklist-append \
                     {*gcc-[3-4].*} {clang < 1001}
+
+platform darwin 8 {
+    configure.cflags-append -Wno-incompatible-pointer-types
+}


### PR DESCRIPTION
I noticed this while updating. Not the only port I ran into this on. I wonder if 14.3 is stricter than earlier gcc. Regardless, the fix is simple.