### PR TITLE
glew: default to X11 for Tiger

### DIFF
--- a/graphics/glew/Portfile
+++ b/graphics/glew/Portfile
@@ -55,11 +55,6 @@ variant x11 description "Build libGLEW for GLX rather than OpenGL.framework" {
                     GLEW_APPLE_GLX=1
 }
 
-if {${os.subplatform} ne "macosx"} {
-    default_variants +x11
-}
-
-platform darwin 8 {
-    # Tiger is missing symbols in its OpenGL, so it needs to build X11
+if {${os.subplatform} ne "macosx" || ${os.major} == 8} {
     default_variants +x11
 }


### PR DESCRIPTION
Tiger's opengl isn't modern enough for glew to build against.