### PR TITLE
Libjxl: fix build on Tiger

### DIFF
--- a/graphics/libjxl/Portfile
+++ b/graphics/libjxl/Portfile
@@ -86,4 +86,10 @@ variant tests description {Enable building of test code} {
     test.run        yes
 }
 
+platform darwin 8 {
+    configure.args-append   -DJPEGXL_ENABLE_BENCHMARK=OFF
+    configure.args-replace  -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+                            -DCMAKE_BUILD_WITH_INSTALL_RPATH=OFF
+}
+
 github.livecheck.regex  {([\d.]+)}


### PR DESCRIPTION
Tiger doesn't have rpath and the benchmarking pulls in something Tiger doesn't have. As far as I can tell, it does no harm to disable both.