### PR TITLE
Fastfetch: update 0016-Tiger-specific-adjustments-to-CMakeLists.patch

### DIFF
--- a/sysutils/fastfetch/files/0016-Tiger-specific-adjustments-to-CMakeLists.patch
+++ b/sysutils/fastfetch/files/0016-Tiger-specific-adjustments-to-CMakeLists.patch
@@ -1,42 +1,39 @@
-From 395bcd42075a2638f4eedc62107ec55b240273b4 Mon Sep 17 00:00:00 2001
-From: Sergey Fedorov <barracuda@macos-powerpc.org>
-Date: Wed, 6 Nov 2024 14:43:00 +0800
-Subject: [PATCH] Tiger-specific adjustments to CMakeLists
-
----
- CMakeLists.txt | 9 ++++-----
- 1 file changed, 4 insertions(+), 5 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 09ae13a5..4605edd8 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -935,11 +935,11 @@
+@@ -942,12 +942,12 @@ elseif(APPLE)
          src/common/impl/processing_linux.c
          src/common/impl/sysctl.c
          src/common/impl/FFPlatform_unix.c
 -        src/common/impl/binary_apple.c
 +        src/common/impl/binary_linux.c
+         src/common/impl/kmod_apple.c
          src/common/apple/cf_helpers.c
          src/common/apple/osascript.m
          src/common/apple/smc_temps.c
 -        src/detection/battery/battery_apple.c
 +        src/detection/battery/battery_nosupport.c
-         src/detection/bios/bios_apple.c
          src/detection/bluetooth/bluetooth_nosupport.c
          src/detection/bluetoothradio/bluetoothradio_nosupport.c
-@@ -954,8 +954,8 @@
+         src/detection/bootmgr/bootmgr_apple.c
+@@ -959,7 +959,7 @@ elseif(APPLE)
          src/detection/cursor/cursor_apple.m
          src/detection/disk/disk_bsd.c
          src/detection/dns/dns_apple.c
 -        src/detection/physicaldisk/physicaldisk_apple.c
--        src/detection/physicalmemory/physicalmemory_apple.m
 +        src/detection/physicaldisk/physicaldisk_nosupport.c
-+        src/detection/physicalmemory/physicalmemory_nosupport.c
          src/detection/diskio/diskio_apple.c
          src/detection/displayserver/displayserver_apple.c
          src/detection/font/font_apple.m
-@@ -1675,7 +1675,6 @@
+@@ -1015,7 +1015,7 @@ elseif(APPLE)
+             src/detection/board/board_apple.c
+             src/detection/chassis/chassis_apple.c
+             src/detection/host/host_apple.c
+-            src/detection/physicalmemory/physicalmemory_apple.m
++            src/detection/physicalmemory/physicalmemory_nosupport.c
+         )
+     endif()
+ elseif(WIN32)
+@@ -1711,7 +1711,6 @@ elseif(APPLE)
          PRIVATE "-framework Cocoa"
          PRIVATE "-framework CoreFoundation"
          PRIVATE "-framework CoreAudio"


### PR DESCRIPTION
The CMakeLists.txt was changed a bit causing the old patch to no longer apply. This fixes the build on 10.5