### PR TITLE
pulseaudio: fix sample format on big endian, revbump

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -10,7 +10,7 @@ PortGroup           perl5 1.0
 
 name                pulseaudio
 version             17.0
-revision            5
+revision            6
 license             {BSD LGPL-2.1+ MIT}
 categories          audio
 maintainers         {ionic @Ionic} openmaintainer
@@ -85,8 +85,10 @@ platform darwin 8 {
 
 platform darwin powerpc {
     # This fixes a segfault on launch of pulseaudio on ppc.
+    # Small fix for hardcoded LE sample format is also needed.
     patchfiles-append \
-                    patch-avoid-segfault-on-powerpc.diff
+                    patch-avoid-segfault-on-powerpc.diff \
+                    patch-fix-big-endian.diff
 }
 
 meson.native.binaries-append \

--- a/audio/pulseaudio/files/patch-fix-big-endian.diff
+++ b/audio/pulseaudio/files/patch-fix-big-endian.diff
@@ -1,0 +1,20 @@
+--- src/modules/macosx/module-coreaudio-device.c.orig
++++ src/modules/macosx/module-coreaudio-device.c
+@@ -474,7 +474,7 @@ static int ca_device_create_sink(pa_module *m, AudioBuffer *buf, int channel_idx
+     }
+
+     ca_sink->ss.rate = u->stream_description.mSampleRate;
+-    ca_sink->ss.format = PA_SAMPLE_FLOAT32LE;
++    ca_sink->ss.format = PA_SAMPLE_FLOAT32BE;
+
+     pa_sink_new_data_init(&new_data);
+     new_data.card = u->card;
+@@ -613,7 +613,7 @@ static int ca_device_create_source(pa_module *m, AudioBuffer *buf, int channel_i
+     }
+
+     ca_source->ss.rate = u->stream_description.mSampleRate;
+-    ca_source->ss.format = PA_SAMPLE_FLOAT32LE;
++    ca_source->ss.format = PA_SAMPLE_FLOAT32BE;
+
+     pa_source_new_data_init(&new_data);
+     new_data.card = u->card;


### PR DESCRIPTION
I  don't know if this is the right way to do it, but it works. Have working audio on 10.5 now instead of just static.