### PR TITLE
openal-soft: fix coreaudio build on Leopard

### DIFF
--- a/audio/openal-soft/Portfile
+++ b/audio/openal-soft/Portfile
@@ -93,6 +93,10 @@ if {[vercmp ${version} < 1.24.0]} {
     # no member named 'join' in namespace 'std::ranges::views'
     compiler.blacklist-append   {clang < 1700}
 }
+
+# This is needed for compatibility with CoreAudio on 10.5
+patchfiles-append patch-fix-coreaudio-leopard.diff
+
 compiler.thread_local_storage   yes
 
 configure.args-append   -DALSOFT_EXAMPLES=OFF \

--- a/audio/openal-soft/files/patch-fix-coreaudio-leopard.diff
+++ b/audio/openal-soft/files/patch-fix-coreaudio-leopard.diff
@@ -1,0 +1,18 @@
+--- alc/backends/coreaudio.cpp.orig
++++ alc/backends/coreaudio.cpp
+@@ -55,6 +55,15 @@
+ #define CAN_ENUMERATE 1
+ #endif
+
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++typedef Component AudioComponent;
++typedef ComponentDescription AudioComponentDescription;
++#define AudioComponentFindNext FindNextComponent
++#define AudioComponentInstanceNew OpenAComponent
++#define AudioComponentInstanceDispose CloseComponent
++#define kAudioUnitProperty_ShouldAllocateBuffer 0
++#endif
++
+ namespace {
+
+ constexpr auto OutputElement = 0;


### PR DESCRIPTION
This fixes the CoreAudio backend on 10.5. 

With this working, I can now use `gstreamer1-gst-plugins-bad` and `lollypop`, which all depend on each other. 

I can also confirm that audio in Quod Libet and my WIP High Tide port works without PulseAudio now.

It's not perfect. On exit I always get the following with Lollypop and Quod Libet:
```
[ALSOFT] (EE) AudioObjectRemovePropertyListener fail: 1970171760
```

And my WIP High Tide port crashes on exit now (Python crash):
```
/opt/local/include/gcc14/c++/bits/std_mutex.h:158: std::__condvar::~__condvar(): Assertion '__e != 16' failed
```

Can't figure out why. But this is a minor inconvenience compared to having it not working I would say.