### PR TITLE
nulloy: add zip port as build dependency

### DIFF
--- a/audio/nulloy/Portfile
+++ b/audio/nulloy/Portfile
@@ -21,7 +21,8 @@ github.tarball_from archive
 
 depends_build-append \
                     port:makeicns \
-                    path:bin/pkg-congig:pkgconfig
+                    path:bin/pkg-congig:pkgconfig \
+                    port:zip
 
 depends_lib-append  port:gstreamer1 \
                     port:gstreamer1-gst-libav \


### PR DESCRIPTION
Nulloy does not build with old system zip, at least on 10.5:
```
make[1]: Leaving directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src/plugins/pluginGstreamer'
cd src/plugins/pluginTaglib/ && /usr/bin/make -f Makefile all
make[1]: Entering directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src/plugins/pluginTaglib'
make[1]: Nothing to be done for `all'.
make[1]: Leaving directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src/plugins/pluginTaglib'
cd src/ && /usr/bin/make -f Makefile all
make[1]: Entering directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src'
zip -j -X -x\*design.svg /opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/nulloy.app/Contents/MacOS/skins/metro.nzs /opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src/skins/metro/*
zip -j -X -x\*design.svg /opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/nulloy.app/Contents/MacOS/skins/silver.nzs /opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src/skins/silver/*

zip error: Invalid command arguments (use -x or -i after name of zipfile)

zip error: Invalid command arguments (use -x or -i after name of zipfile)
make[1]: *** [/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/nulloy.app/Contents/MacOS/skins/silver.nzs] Error 16
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/nulloy.app/Contents/MacOS/skins/metro.nzs] Error 16
make[1]: Leaving directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04/src'
make: *** [sub--opt-local-var-macports-build-nulloy-7635a7cd-work-nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04-src-all-ordered] Error 2
make: Leaving directory `/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04'
Command failed:  cd "/opt/local/var/macports/build/nulloy-7635a7cd/work/nulloy-6369f88d99b5dfab9e635c65d23640a7c7ccdc04" && /usr/bin/make -j4 -w all
Exit code: 2
Error: Failed to build nulloy: command execution failed
DEBUG: Error code: CHILDSTATUS 60679 2
```