### PR TITLE
QMPlay2: Fix Tiger build

### DIFF
--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -78,12 +78,13 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
     # configure.cppflags-append \
                     -DUSE_QRAWFONT
 
-    # FIXME: specifically on Tiger this fails:
-    # OpenGL2Common.cpp:258:44: error: call of overloaded 'setUniformValue(const char*, int)' is ambiguous
-    # Disable for now, GL is optional anyway.
     platform darwin 8 {
-        configure.args-replace \
-                    -DUSE_OPENGL2=ON -DUSE_OPENGL2=OFF
+        patchfiles-append \
+                    tiger-fixes.patch
+        post-patch {
+            reinplace "s|@qt_tiger_plugins_dir@|${prefix}/share/qt4/plugins|" ${worksrcpath}/src/gui/CMakeLists.txt
+        }
+        configure.cxxflags-append -fpermissive
     }
 
     post-destroot {
@@ -290,4 +291,41 @@ variant pulse description "Use Pulseaudio" {
                     port:pulseaudio
     configure.args-replace \
                     -DUSE_PULSEAUDIO=OFF -DUSE_PULSEAUDIO=ON
+}
+
+variant lto description "Enable LTO" {
+    # Does not seem to do anything on its own.
+    configure.args-replace \
+                    -DUSE_LINK_TIME_OPTIMIZATION=OFF \
+                    -DUSE_LINK_TIME_OPTIMIZATION=ON
+    # So just pass flags explicitly:
+    configure.cxxflags-append \
+                    -flto
+    configure.ldflags-append \
+                    -flto
+}
+
+variant G4 conflicts G5 description "Optimize for G4" {
+    configure.cxxflags-append \
+                    -mcpu=G4 -mtune=G4
+}
+
+variant G5 conflicts G4 description "Optimize for G5" {
+    configure.cxxflags-append \
+                    -mcpu=970 -mtune=970
+
+    # https://github.com/iains/gcc-14-branch/issues/24
+    if {${configure.build_arch} ne "ppc64"} {
+        configure.cxxflags-append \
+                    -mno-powerpc64
+    }
+}
+
+if {${os.platform} ne "darwin" || ${os.major} > 9} {
+    default_variants-append +lto
+}
+
+# ppc64 can only be built on a G5, so default to that.
+if {${os.platform} eq "darwin" && ${configure.build_arch} eq "ppc64"} {
+    default_variants-append +G5
 }

--- a/multimedia/QMPlay2/Portfile
+++ b/multimedia/QMPlay2/Portfile
@@ -81,9 +81,6 @@ if {${os.platform} eq "darwin" && ${os.major} < 15} {
     platform darwin 8 {
         patchfiles-append \
                     tiger-fixes.patch
-        post-patch {
-            reinplace "s|@qt_tiger_plugins_dir@|${prefix}/share/qt4/plugins|" ${worksrcpath}/src/gui/CMakeLists.txt
-        }
         configure.cxxflags-append -fpermissive
     }
 
@@ -291,41 +288,4 @@ variant pulse description "Use Pulseaudio" {
                     port:pulseaudio
     configure.args-replace \
                     -DUSE_PULSEAUDIO=OFF -DUSE_PULSEAUDIO=ON
-}
-
-variant lto description "Enable LTO" {
-    # Does not seem to do anything on its own.
-    configure.args-replace \
-                    -DUSE_LINK_TIME_OPTIMIZATION=OFF \
-                    -DUSE_LINK_TIME_OPTIMIZATION=ON
-    # So just pass flags explicitly:
-    configure.cxxflags-append \
-                    -flto
-    configure.ldflags-append \
-                    -flto
-}
-
-variant G4 conflicts G5 description "Optimize for G4" {
-    configure.cxxflags-append \
-                    -mcpu=G4 -mtune=G4
-}
-
-variant G5 conflicts G4 description "Optimize for G5" {
-    configure.cxxflags-append \
-                    -mcpu=970 -mtune=970
-
-    # https://github.com/iains/gcc-14-branch/issues/24
-    if {${configure.build_arch} ne "ppc64"} {
-        configure.cxxflags-append \
-                    -mno-powerpc64
-    }
-}
-
-if {${os.platform} ne "darwin" || ${os.major} > 9} {
-    default_variants-append +lto
-}
-
-# ppc64 can only be built on a G5, so default to that.
-if {${os.platform} eq "darwin" && ${configure.build_arch} eq "ppc64"} {
-    default_variants-append +G5
 }

--- a/multimedia/QMPlay2/files/tiger-fixes.patch
+++ b/multimedia/QMPlay2/files/tiger-fixes.patch
@@ -42,18 +42,6 @@
          shaderProgramVideo->setUniformValue("uTextureSize", m_textureSize);
  
          doReset = !resetDone;
---- a/src/gui/CMakeLists.txt
-+++ b/src/gui/CMakeLists.txt
-@@ -231,8 +231,8 @@
- elseif(APPLE)
-     install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
- 
-     set(QT_LIBS_DIR "@qt_libs_dir@")
--    set(QT_PLUGINS_DIR "@qt_plugins_dir@")
-+    set(QT_PLUGINS_DIR "@qt_tiger_plugins_dir@")
- if(NOT USE_QT4)
-     install(FILES
-         "${QT_PLUGINS_DIR}/platforms/libqcocoa.dylib"
 --- a/src/gui/MacOS/ScreenSaver.cpp
 +++ b/src/gui/MacOS/ScreenSaver.cpp
 @@ -31,57 +31,32 @@

--- a/multimedia/QMPlay2/files/tiger-fixes.patch
+++ b/multimedia/QMPlay2/files/tiger-fixes.patch
@@ -1,0 +1,116 @@
+--- a/src/modules/OpenGL2/OpenGL2Common.cpp
++++ b/src/modules/OpenGL2/OpenGL2Common.cpp
+@@ -257,15 +257,15 @@
+     if (shaderProgramVideo->bind())
+     {
+         texCoordYCbCrLoc = shaderProgramVideo->attributeLocation("aTexCoord");
+         positionYCbCrLoc = shaderProgramVideo->attributeLocation("aPosition");
+-        shaderProgramVideo->setUniformValue((numPlanes == 1) ? "uRGB" : "uY" , 0);
++        shaderProgramVideo->setUniformValue((numPlanes == 1) ? "uRGB" : "uY" , static_cast<GLint>(0));
+         if (numPlanes == 2)
+-            shaderProgramVideo->setUniformValue("uCbCr", 1);
++            shaderProgramVideo->setUniformValue("uCbCr", static_cast<GLint>(1));
+         else if (numPlanes == 3)
+         {
+-            shaderProgramVideo->setUniformValue("uCb", 1);
+-            shaderProgramVideo->setUniformValue("uCr", 2);
++            shaderProgramVideo->setUniformValue("uCb", static_cast<GLint>(1));
++            shaderProgramVideo->setUniformValue("uCr", static_cast<GLint>(2));
+         }
+         shaderProgramVideo->release();
+     }
+     else
+@@ -281,9 +281,9 @@
+     if (shaderProgramOSD->bind())
+     {
+         texCoordOSDLoc = shaderProgramOSD->attributeLocation("aTexCoord");
+         positionOSDLoc = shaderProgramOSD->attributeLocation("aPosition");
+-        shaderProgramOSD->setUniformValue("uTex", 3);
++        shaderProgramOSD->setUniformValue("uTex", static_cast<GLint>(3));
+         shaderProgramOSD->release();
+     }
+     else
+     {
+@@ -570,9 +570,9 @@
+             const qreal dpr = widget()->devicePixelRatioF();
+             if (!resetDone)
+                 maybeSetMipmaps(dpr);
+             const bool useBicubic = (W * dpr > m_textureSize.width() || H * dpr > m_textureSize.height());
+-            shaderProgramVideo->setUniformValue("uBicubic", useBicubic ? 1 : 0);
++            shaderProgramVideo->setUniformValue("uBicubic", useBicubic ? static_cast<GLint>(1) : static_cast<GLint>(0));
+         }
+         shaderProgramVideo->setUniformValue("uTextureSize", m_textureSize);
+ 
+         doReset = !resetDone;
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -231,8 +231,8 @@
+ elseif(APPLE)
+     install(TARGETS ${PROJECT_NAME} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+ 
+     set(QT_LIBS_DIR "@qt_libs_dir@")
+-    set(QT_PLUGINS_DIR "@qt_plugins_dir@")
++    set(QT_PLUGINS_DIR "@qt_tiger_plugins_dir@")
+ if(NOT USE_QT4)
+     install(FILES
+         "${QT_PLUGINS_DIR}/platforms/libqcocoa.dylib"
+--- a/src/gui/MacOS/ScreenSaver.cpp
++++ b/src/gui/MacOS/ScreenSaver.cpp
+@@ -31,57 +31,32 @@
+ public:
+     inline ~ScreenSaverPriv()
+     {
+-        unInhibit();
+     }
+ 
+     inline void inhibit()
+     {
+-#if defined(__APPLE__) && (MAC_OS_X_VERSION_MAX_ALLOWED < 1060)
+-        m_okDisp = (IOPMAssertionCreate(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, &m_idDisp) == kIOReturnSuccess);
+-        m_okSys  = (IOPMAssertionCreate(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, &m_idSys)  == kIOReturnSuccess);
+-#else
+-        m_okDisp = (IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, QMPLAY2_MEDIA_PLAYBACK, &m_idDisp) == kIOReturnSuccess);
+-        m_okSys  = (IOPMAssertionCreateWithName(kIOPMAssertionTypeNoIdleSleep, kIOPMAssertionLevelOn, QMPLAY2_MEDIA_PLAYBACK, &m_idSys) == kIOReturnSuccess);
+-#endif
+     }
+     inline void unInhibit()
+     {
+-        if (m_okDisp)
+-        {
+-            IOPMAssertionRelease(m_idDisp);
+-            m_okDisp = false;
+-        }
+-        if (m_okSys)
+-        {
+-            IOPMAssertionRelease(m_idSys);
+-            m_okSys = false;
+-        }
+     }
+ 
+ private:
+-    IOPMAssertionID m_idDisp;
+-    IOPMAssertionID m_idSys;
+     bool m_okDisp = false;
+     bool m_okSys  = false;
+ };
+ 
+ /**/
+ 
+ ScreenSaver::ScreenSaver() :
+     m_priv(new ScreenSaverPriv)
+ {}
+ ScreenSaver::~ScreenSaver()
+ {
+-    delete m_priv;
+ }
+ 
+ void ScreenSaver::inhibit(int context)
+ {
+-    if (inhibitHelper(context))
+-        m_priv->inhibit();
+ }
+ void ScreenSaver::unInhibit(int context)
+ {
+-    if (unInhibitHelper(context))
+-        m_priv->unInhibit();
+ }


### PR DESCRIPTION
Relevant to all OS - I restored variants, which is important for low end G4s and G5s.
QT4 from powerpc-ports installs the plugins directory to a different place on 10.4 than on 10.5 or higher, but that is easy to patch in relevant ports with reinplace. The screensaver code seems too much effort to fix properly, so I converted into stubs. I also fixed the ambiguous OpenGL call, but I am still not seeing better performance from OpenGL2 than software rendering (480p, Youtube, h.264 preferred). Could be a Tiger issue, or more likely a 32MB of VRAM issue. I will test on a PowerBook with 128 MB of VRAM later and see if that improves OpenGL2 enough to make it worth using. On that same hardware I have a Leopard partition so I can see if Tiger is the issue instead of the hardware.