### PR TITLE
ffmpeg, ffmpeg4, ffmpeg5: add missing kaudioformats on 10.5, fixes build

### DIFF
--- a/multimedia/ffmpeg/Portfile
+++ b/multimedia/ffmpeg/Portfile
@@ -102,6 +102,9 @@ depends_lib-append  port:aom \
 
 patchfiles-append   patch-libavcodec-audiotoolboxenc.c.diff
 
+# Some kAudioFormat's are not defined on 10.5
+patchfiles-append   patch-leopard-kaudioformat.diff
+
 # Fix an upstream bug that overrides the max_b_frames setting
 # https://trac.ffmpeg.org/ticket/9231
 # Fixed via upstream commit: 55d9d6767967794edcdd6e1bbd8840fc6f4e9315

--- a/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
@@ -30,4 +30,5 @@
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
 
- typedef struct ATDecodeConte
+ typedef struct ATDecodeContext {
+     AVClass *av_class;

--- a/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
@@ -1,10 +1,16 @@
 --- libavcodec/audiotoolboxdec.c.orig
 +++ libavcodec/audiotoolboxdec.c
-@@ -36,6 +36,11 @@
+@@ -31,11 +31,17 @@
+ #include "libavutil/avassert.h"
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
++#include <AvailabilityMacros.h>
+
+ #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
  #define kAudioFormatEnhancedAC3 'ec-3'
  #endif
 
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatMicrosoftGSM 0x6D730031
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
@@ -14,14 +20,14 @@
 
 --- libavcodec/audiotoolboxenc.c.orig
 +++ libavcodec/audiotoolboxenc.c
-@@ -35,6 +35,10 @@
+@@ -34,6 +34,11 @@
+ #include "libavutil/avassert.h"
  #include "libavutil/opt.h"
  #include "libavutil/log.h"
-
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#include <AvailabilityMacros.h>
++
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
-+
- typedef struct ATDecodeContext {
-     AVClass *av_class;
-     int mode;
+
+ typedef struct ATDecodeConte

--- a/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg/files/patch-leopard-kaudioformat.diff
@@ -1,0 +1,27 @@
+--- libavcodec/audiotoolboxdec.c.orig
++++ libavcodec/audiotoolboxdec.c
+@@ -36,6 +36,11 @@
+ #define kAudioFormatEnhancedAC3 'ec-3'
+ #endif
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatMicrosoftGSM 0x6D730031
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+
+--- libavcodec/audiotoolboxenc.c.orig
++++ libavcodec/audiotoolboxenc.c
+@@ -35,6 +35,10 @@
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+     int mode;

--- a/multimedia/ffmpeg4/Portfile
+++ b/multimedia/ffmpeg4/Portfile
@@ -115,6 +115,9 @@ depends_lib-append  port:aom \
 
 patchfiles-append   patch-libavcodec-audiotoolboxenc.c.diff
 
+# Some kAudioFormat's are not defined on 10.5
+patchfiles-append   patch-leopard-kaudioformat.diff
+
 # Fix an upstream bug that overrides the max_b_frames setting
 # https://trac.ffmpeg.org/ticket/9231
 # Fixed via upstream commit: 55d9d6767967794edcdd6e1bbd8840fc6f4e9315

--- a/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
@@ -30,4 +30,5 @@
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
 
- typedef struct ATDecodeConte
+ typedef struct ATDecodeContext {
+     AVClass *av_class;

--- a/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
@@ -1,10 +1,16 @@
 --- libavcodec/audiotoolboxdec.c.orig
 +++ libavcodec/audiotoolboxdec.c
-@@ -36,6 +36,11 @@
+@@ -31,11 +31,17 @@
+ #include "libavutil/avassert.h"
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
++#include <AvailabilityMacros.h>
+
+ #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
  #define kAudioFormatEnhancedAC3 'ec-3'
  #endif
 
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatMicrosoftGSM 0x6D730031
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
@@ -14,14 +20,14 @@
 
 --- libavcodec/audiotoolboxenc.c.orig
 +++ libavcodec/audiotoolboxenc.c
-@@ -35,6 +35,10 @@
+@@ -34,6 +34,11 @@
+ #include "libavutil/avassert.h"
  #include "libavutil/opt.h"
  #include "libavutil/log.h"
-
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#include <AvailabilityMacros.h>
++
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
-+
- typedef struct ATDecodeContext {
-     AVClass *av_class;
-     int mode;
+
+ typedef struct ATDecodeConte

--- a/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg4/files/patch-leopard-kaudioformat.diff
@@ -1,0 +1,27 @@
+--- libavcodec/audiotoolboxdec.c.orig
++++ libavcodec/audiotoolboxdec.c
+@@ -36,6 +36,11 @@
+ #define kAudioFormatEnhancedAC3 'ec-3'
+ #endif
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatMicrosoftGSM 0x6D730031
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+
+--- libavcodec/audiotoolboxenc.c.orig
++++ libavcodec/audiotoolboxenc.c
+@@ -35,6 +35,10 @@
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+     int mode;

--- a/multimedia/ffmpeg5/Portfile
+++ b/multimedia/ffmpeg5/Portfile
@@ -97,6 +97,9 @@ depends_lib-append  port:aom \
 
 patchfiles-append   patch-avutil-builtin-available.diff
 
+# Some kAudioFormat's are not defined on 10.5
+patchfiles-append   patch-leopard-kaudioformat.diff
+
 # Additional fixes related to use of '__builtin_available'
 # TODO: Submit patches to upstream
 patchfiles-append   patch-libavcodec-profvidworkflow.diff

--- a/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
@@ -30,4 +30,5 @@
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
 
- typedef struct ATDecodeConte
+ typedef struct ATDecodeContext {
+     AVClass *av_class;

--- a/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
@@ -1,10 +1,16 @@
 --- libavcodec/audiotoolboxdec.c.orig
 +++ libavcodec/audiotoolboxdec.c
-@@ -36,6 +36,11 @@
+@@ -31,11 +31,17 @@
+ #include "libavutil/avassert.h"
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
++#include <AvailabilityMacros.h>
+
+ #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101100
  #define kAudioFormatEnhancedAC3 'ec-3'
  #endif
 
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatMicrosoftGSM 0x6D730031
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
@@ -14,14 +20,14 @@
 
 --- libavcodec/audiotoolboxenc.c.orig
 +++ libavcodec/audiotoolboxenc.c
-@@ -35,6 +35,10 @@
+@@ -34,6 +34,11 @@
+ #include "libavutil/avassert.h"
  #include "libavutil/opt.h"
  #include "libavutil/log.h"
-
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#include <AvailabilityMacros.h>
++
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1060
 +#define kAudioFormatiLBC 'ilbc'
 +#endif
-+
- typedef struct ATDecodeContext {
-     AVClass *av_class;
-     int mode;
+
+ typedef struct ATDecodeConte

--- a/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
+++ b/multimedia/ffmpeg5/files/patch-leopard-kaudioformat.diff
@@ -1,0 +1,27 @@
+--- libavcodec/audiotoolboxdec.c.orig
++++ libavcodec/audiotoolboxdec.c
+@@ -36,6 +36,11 @@
+ #define kAudioFormatEnhancedAC3 'ec-3'
+ #endif
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatMicrosoftGSM 0x6D730031
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+
+--- libavcodec/audiotoolboxenc.c.orig
++++ libavcodec/audiotoolboxenc.c
+@@ -35,6 +35,10 @@
+ #include "libavutil/opt.h"
+ #include "libavutil/log.h"
+
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1060
++#define kAudioFormatiLBC 'ilbc'
++#endif
++
+ typedef struct ATDecodeContext {
+     AVClass *av_class;
+     int mode;


### PR DESCRIPTION
ps: why do we have both `ffmpeg` and `ffmpeg4`?