### PR TITLE
git: fix build on Tiger

### DIFF
--- a/devel/git/Portfile
+++ b/devel/git/Portfile
@@ -359,7 +359,7 @@ variant svn description {Bi-directional subversion repository support} {
 variant credential_osxkeychain description {Install git credential-osxkeychain utility from contrib} {
 
     post-build {
-        system -W "${worksrcpath}/contrib/credential/osxkeychain" "make [join ${build.args}]"
+        system -W "${worksrcpath}/contrib/credential/osxkeychain" "${build.cmd} [join ${build.args}]"
     }
 
     post-destroot {
@@ -406,7 +406,7 @@ For more information, run
 
 variant diff_highlight description {Install git diff-highlight utility from contrib} {
     post-build {
-        system -W "${worksrcpath}/contrib/diff-highlight" "make [join ${build.args}]"
+        system -W "${worksrcpath}/contrib/diff-highlight" "${build.cmd} [join ${build.args}]"
     }
 
     post-destroot {
@@ -432,8 +432,9 @@ platform darwin 11 {
 
 platform darwin 8 {
     # https://trac.macports.org/ticket/66480
-    depends_build-append port:gmake-apple
-    build.cmd  ${prefix}/bin/gmake-apple
+    depends_build-append port:gmake
+    build.cmd  ${prefix}/bin/gmake
+    test.cmd   ${prefix}/bin/gmake
 
     build.args-append   NO_APPLE_COMMON_CRYPTO=1
     build.args-append   CC_LD_DYNPATH=-R


### PR DESCRIPTION
make fails to build git on Tiger, so I switched where it was hardcoded in the Portfile to ${build.cmd} and it built. Let me know if that change is problematic. 