### PR TITLE
pulseaudio: fix build on Tiger

### DIFF
--- a/audio/pulseaudio/Portfile
+++ b/audio/pulseaudio/Portfile
@@ -81,6 +81,8 @@ patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-respect-P
 
 platform darwin 8 {
     patchfiles-append   patch-src_modules_macosx_module_coreaudio_device.c-tiger-compat.diff
+    configure.cflags-append \
+                    -Wno-error=implicit-function-declaration
 }
 
 platform darwin powerpc {


### PR DESCRIPTION
Apparently there is a Carbon header that gets included that has an implicit function declaration. I decided to just turn the error into a warning to get it to build. Hopefully that will not cause other problems.