### PR TITLE
claws-mail: Update to 4.4.0

### DIFF
--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -4,8 +4,8 @@ PortSystem      1.0
 PortGroup       active_variants 1.1
 
 name            claws-mail
-version         4.3.1
-revision        1
+version         4.4.0
+revision        0
 categories      mail news
 license         GPL-3+
 maintainers     nomaintainer
@@ -23,9 +23,9 @@ long_description \
 homepage        https://www.claws-mail.org
 master_sites    ${homepage}/releases/
 
-checksums       rmd160  bd42f3bc81dedff823f85f956c953235eb2299c0 \
-                sha256  d8adf210c767ab58252dfc5ab3c69e603d7ffdb7281a1e3340d2d86062f468a6 \
-                size    6782236
+checksums       rmd160  e06f5ed11bf560885905023fa50a75fa02f1d77a \
+                sha256  03e0549d5f0fcd7a59804186524105d05ebb5e534d42a4b86a9a90f729ca255b \
+                size    6723204
 
 use_xz          yes
 


### PR DESCRIPTION
Claws-mail had a new release a couple months ago. It hasn't finished compiling on my Tiger machine, but I figure fixes can be a separate commit for clarity reasons anyway. You may want to test on 10.6 before merging.