### PR TITLE
ytcui: fix build on Tiger

### DIFF
--- a/www/ytcui/Portfile
+++ b/www/ytcui/Portfile
@@ -43,6 +43,12 @@ depends_run-append  port:chafa \
 
 compiler.cxx_standard   2017
 
+platform darwin 8 {
+    depends_build-append \
+                    port:gmake
+    build.cmd       gmake
+}
+
 variant yt_dlp description "Build with yt-dlp backend instead of the native one" {
     depends_run-append \
                     port:yt-dlp


### PR DESCRIPTION
Works with gmake and mpv-legacy on Tiger. No sound, but that is an issue with streaming with mpv-legacy on Tiger, not an issue with this port.