### PR TITLE
ytcui-dl: fix build on Tiger

### DIFF
--- a/net/ytcui-dl/Portfile
+++ b/net/ytcui-dl/Portfile
@@ -36,3 +36,9 @@ depends_build-append \
 depends_lib-append  port:curl
 
 compiler.cxx_standard   2017
+
+platform darwin 8 {
+    depends_build-append \
+                    port:gmake
+    build.cmd       gmake
+}


### PR DESCRIPTION
Works with gmake. Much faster than yt-dlp but seems to have trouble with some formats.