### PR TITLE
claws-mail: fix build on Tiger

### DIFF
--- a/mail/claws-mail/Portfile
+++ b/mail/claws-mail/Portfile
@@ -98,6 +98,11 @@ configure.checks.implicit_function_declaration.whitelist-append strchr
 configure.env-append \
                 REAL_CXX=${configure.cxx}
 
+platform darwin 8 {
+    configure.cflags-append \
+                -Wno-error=incompatible-pointer-types
+}
+
 variant quartz conflicts x11 {
     require_active_variants path:lib/pkgconfig/gtk+-3.0.pc:gtk3 quartz
     configure.args-append   --disable-dillo-plugin \


### PR DESCRIPTION
Failed near the end with an incompatible pointer types error. The usual fix worked. I then tested with Gmail and confirmed working.