### PR TITLE
opencolorio: add legacysupport for 10.5 and include stdlib.h

### DIFF
--- a/graphics/opencolorio/Portfile
+++ b/graphics/opencolorio/Portfile
@@ -4,6 +4,10 @@ PortSystem          1.0
 PortGroup           boost 1.0
 PortGroup           cmake  1.1
 PortGroup           github 1.0
+PortGroup           legacysupport 1.1
+
+# posix_memalign
+legacysupport.newest_darwin_requires_legacy 9
 
 boost.version       1.81
 boost.depends_type  build
@@ -31,6 +35,9 @@ if {${os.platform} eq "darwin" && ${os.major} < 11} {
 }
 
 patchfiles-append   0002-fix-broken-linking.patch
+
+# https://github.com/macos-powerpc/powerpc-ports/issues/116
+patchfiles-append   0003-include-stdlib.patch
 
 depends_build-append \
     path:bin/pkg-config:pkgconfig

--- a/graphics/opencolorio/files/0003-include-stdlib.patch
+++ b/graphics/opencolorio/files/0003-include-stdlib.patch
@@ -1,0 +1,10 @@
+--- src/OpenColorIO/Platform.cpp.orig
++++ src/OpenColorIO/Platform.cpp
+@@ -11,6 +11,7 @@
+ #include <OpenColorIO/OpenColorIO.h>
+
+ #include "Platform.h"
++#include "stdlib.h"
+
+ #ifndef _WIN32
+ #include <strings.h>

--- a/graphics/opencolorio/files/0003-include-stdlib.patch
+++ b/graphics/opencolorio/files/0003-include-stdlib.patch
@@ -1,10 +1,10 @@
 --- src/OpenColorIO/Platform.cpp.orig
 +++ src/OpenColorIO/Platform.cpp
-@@ -11,6 +11,7 @@
+@@ -7,6 +7,7 @@
+ #include <sstream>
+ #include <sys/stat.h>
+ #include <vector>
++#include <stdlib.h>
+ 
  #include <OpenColorIO/OpenColorIO.h>
-
- #include "Platform.h"
-+#include "stdlib.h"
-
- #ifndef _WIN32
- #include <strings.h>
+ 


### PR DESCRIPTION
Fixes macos-powerpc/powerpc-ports#116