### PR TITLE
mupdf: fix build on Leopard by linking libunwind

### DIFF
--- a/graphics/mupdf/Portfile
+++ b/graphics/mupdf/Portfile
@@ -71,6 +71,12 @@ if {${os.platform} eq "darwin" && ${configure.cxx_stdlib} ne "libc++"} {
                     -D_GLIBCXX_USE_CXX11_ABI=0
 }
 
+# __Unwind_Resume
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    depends_lib-append port:libunwind
+    configure.ldflags-append -lunwind
+}
+
 build.args          PREFIX=${prefix}
 build.args-append   CC=${configure.cc} \
                     CXX=${configure.cxx} \


### PR DESCRIPTION
This resolves:
```
:info:build Undefined symbols for architecture ppc:
:info:build   "__Unwind_Resume", referenced from:
:info:build       _ocr_init in tessocr.o
:info:build ld: symbol(s) not found for architecture ppc
:info:build collect2: error: ld returned 1 exit status
:info:build make: *** [build/shared-release/libmupdf.dylib] Error 1

```