### PR TITLE
sdlbook: revbump for mupdf update

### DIFF
--- a/office/sdlbook/Portfile
+++ b/office/sdlbook/Portfile
@@ -11,7 +11,7 @@ legacysupport.newest_darwin_requires_legacy 10
 name                sdlbook
 github.setup        rofl0r SDLBook f4de11f6994dad55d9e53152fdfe20fc6bb22d6e
 version             20250401
-revision            0
+revision            1
 categories          office
 maintainers         {@barracuda156 macos-powerpc.org:barracuda} openmaintainer
 license             GPL-3


### PR DESCRIPTION
Sdlbook needs to be be rebuilt against new mupdf, otherwise it blows up at runtime:
```
cannot create context: incompatible header (1.24.2) and library (1.27.2) versions
Segmentation fault
```