### PR TITLE
toxcore: link with -latomic on 10.5

### DIFF
--- a/net/toxcore/Portfile
+++ b/net/toxcore/Portfile
@@ -54,7 +54,7 @@ if {[string match *clang* ${configure.compiler}]} {
 }
 
 # __atomic_*
-if {${os.platform} eq "darwin" && ${os.major} < 10} {
+if {[string match *gcc* ${configure.compiler}] && ${configure.build_arch} in [list arm i386 ppc]} {
     configure.ldflags-append -latomic
 }
 

--- a/net/toxcore/Portfile
+++ b/net/toxcore/Portfile
@@ -53,6 +53,11 @@ if {[string match *clang* ${configure.compiler}]} {
                         -lomp
 }
 
+# __atomic_*
+if {${os.platform} eq "darwin" && ${os.major} < 10} {
+    configure.ldflags-append -latomic
+}
+
 notes "
 This is an experimental cryptographic network library.\
 It has not been formally audited by an independent third party\


### PR DESCRIPTION
This fixes the build:
```
:info:build [ 90%] Linking CXX executable unit_TCP_client_test
:info:build /opt/local/bin/cmake -E cmake_link_script CMakeFiles/unit_TCP_client_test.dir/link.txt --verbose=ON
:info:build Undefined symbols for architecture ppc:
:info:build   "___atomic_fetch_add_8", referenced from:
:info:build       tox::test::FakeClock::advance(unsigned long long) in libsupport.a(fake_clock.cc.o)
:info:build   "___atomic_load_8", referenced from:
:info:build       tox::test::FakeClock::current_time_s() const in libsupport.a(fake_clock.cc.o)
:info:build       tox::test::FakeClock::current_time_ms() const in libsupport.a(fake_clock.cc.o)
:info:build ld: symbol(s) not found for architecture ppc
:info:build collect2: error: ld returned 1 exit status**
```