### PR TITLE
libsdl2-cocoa: Fix Tiger build by restoring old joystick workaround

### DIFF
--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -56,6 +56,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 9} {
                     --disable-hidapi \
                     --disable-hidapi-joystick \
                     --disable-locale
+
+    # restore old joystick workaround
+    patchfiles-replace \
+                    0004-enable-iokit-joystick.diff \
+                    tiger-patch-joystick.diff
 }
 
 build.args          V=1

--- a/devel/libsdl2-cocoa/files/tiger-patch-joystick.diff
+++ b/devel/libsdl2-cocoa/files/tiger-patch-joystick.diff
@@ -1,0 +1,45 @@
+--- include/SDL_config_macosx.h	2025-10-04 13:12:07.000000000 +0800
++++ include/SDL_config_macosx.h	2025-10-04 13:26:51.000000000 +0800
+@@ -158,8 +158,13 @@
+ #define SDL_AUDIO_DRIVER_DUMMY  1
+ 
+ /* Enable various input drivers */
+-#define SDL_JOYSTICK_HIDAPI 1
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+ #define SDL_JOYSTICK_IOKIT  1
++#else
++#define SDL_JOYSTICK_DUMMY  1
++#endif
++
++#define SDL_JOYSTICK_HIDAPI 1
+ #define SDL_JOYSTICK_VIRTUAL    1
+ #define SDL_HAPTIC_IOKIT    1
+ 
+--- configure	2025-09-02 05:33:27.000000000 +0800
++++ configure	2025-10-04 14:13:29.000000000 +0800
+@@ -29461,11 +29463,9 @@
+         # Set up files for the joystick library
+         if test x$enable_joystick = xyes; then
+ 
+-printf "%s\n" "#define SDL_JOYSTICK_IOKIT 1" >>confdefs.h
++printf "%s\n" "#define SDL_JOYSTICK_DUMMY 1" >>confdefs.h
+ 
+-            SOURCES="$SOURCES $srcdir/src/joystick/darwin/*.c"
+-            SOURCES="$SOURCES $srcdir/src/joystick/iphoneos/*.m"
+-            CheckJoystickMFI
++            SOURCES="$SOURCES $srcdir/src/joystick/dummy/*.c"
+             have_joystick=yes
+         fi
+         # Set up files for the haptic library
+
+--- src/joystick/SDL_joystick.c	2025-01-01 23:47:53.000000000 +0800
++++ src/joystick/SDL_joystick.c	2025-10-04 14:18:49.000000000 +0800
+@@ -73,7 +73,7 @@
+ #ifdef SDL_JOYSTICK_IOKIT
+     &SDL_DARWIN_JoystickDriver,
+ #endif
+-#if (defined(__MACOSX__) || defined(__IPHONEOS__) || defined(__TVOS__)) && !defined(SDL_JOYSTICK_DISABLED)
++#if (defined(__IPHONEOS__) || defined(__TVOS__)) && !defined(SDL_JOYSTICK_DISABLED)
+     &SDL_IOS_JoystickDriver,
+ #endif
+ #ifdef SDL_JOYSTICK_ANDROID


### PR DESCRIPTION
Tiger lacks what is needed for the joystick code to build.