### PR TITLE
libunwind: Fix Tiger build with legacysupport

### DIFF
--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -1,6 +1,8 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem              1.0
+PortGroup               legacysupport 1.1
+legacysupport.newest_darwin_requires_legacy 8
 
 name                    libunwind
 version                 5.0.1

--- a/devel/libunwind/Portfile
+++ b/devel/libunwind/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem              1.0
 PortGroup               legacysupport 1.1
+
 legacysupport.newest_darwin_requires_legacy 8
 
 name                    libunwind


### PR DESCRIPTION
Legacy support fixes this, which is lucky because I was taking a shot in the dark.