### PR TITLE
libsdl2-cocoa: add conflicts_build port:libunwind-headers

### DIFF
--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -48,21 +48,6 @@ configure.args-append \
                     --enable-video-cocoa \
                     --without-x
 
-# FIXME: look into fixing CoreAudio module for Tiger.
-if {${os.platform} eq "darwin" && ${os.major} < 9} {
-    configure.args-append \
-                    --disable-audio \
-                    --disable-haptic \
-                    --disable-hidapi \
-                    --disable-hidapi-joystick \
-                    --disable-locale
-
-    # restore old joystick workaround
-    patchfiles-replace \
-                    0004-enable-iokit-joystick.diff \
-                    tiger-patch-joystick.diff
-}
-
 build.args          V=1
 
 platform darwin powerpc {
@@ -140,6 +125,23 @@ platform darwin 10 {
     # Anyone with Nvidia-specific 10.6.8 image (or 10a190) can build with `libsdl2-cocoa -oldapi`.
     default_variants-append \
                     +oldapi
+}
+
+# FIXME: look into fixing CoreAudio module for Tiger.
+if {${os.platform} eq "darwin" && ${os.major} < 9} {
+    conflicts_build port:libunwind-headers
+
+    configure.args-append \
+                    --disable-audio \
+                    --disable-haptic \
+                    --disable-hidapi \
+                    --disable-hidapi-joystick \
+                    --disable-locale
+
+    # restore old joystick workaround
+    patchfiles-replace \
+                    0004-enable-iokit-joystick.diff \
+                    tiger-patch-joystick.diff
 }
 
 notes "

--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -32,7 +32,7 @@ checksums           ${main_dist} \
                     size    7630262
 
 # /usr/include/hfs/hfs_format.h: error: expected specifier-qualifier-list before ‘uuid_string_t’
-conflicts_build     libuuid
+conflicts_build     libuuid libunwind-headers
 
 configure.args-append \
                     --disable-dbus \
@@ -129,8 +129,6 @@ platform darwin 10 {
 
 # FIXME: look into fixing CoreAudio module for Tiger.
 if {${os.platform} eq "darwin" && ${os.major} < 9} {
-    conflicts_build libunwind-headers
-
     configure.args-append \
                     --disable-audio \
                     --disable-haptic \

--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -129,7 +129,7 @@ platform darwin 10 {
 
 # FIXME: look into fixing CoreAudio module for Tiger.
 if {${os.platform} eq "darwin" && ${os.major} < 9} {
-    conflicts_build port:libunwind-headers
+    conflicts_build libunwind-headers
 
     configure.args-append \
                     --disable-audio \


### PR DESCRIPTION
Libunwind-headers being active prevents libsdl2-cocoa from building on Tiger, if you could check if this behavior is true on 10.6.8 perhaps that line should be outside of the Tiger block. Regardless, I also want to move the Tiger block to the bottom so that patchfiles-replace works.