### PR TITLE
libcmatrix: fix Tiger build

### DIFF
--- a/devel/libcmatrix/Portfile
+++ b/devel/libcmatrix/Portfile
@@ -52,4 +52,6 @@ configure.args-append \
 platform darwin 8 {
     configure.cflags-append \
                     -Wno-error=format
+    configure.ldflags-append \
+                    -lssp
 }

--- a/devel/libcmatrix/Portfile
+++ b/devel/libcmatrix/Portfile
@@ -48,3 +48,8 @@ configure.args-append \
                     -Dbuild-tests=false \
                     -Dgtk_doc=false \
                     -Dintrospection=true
+
+platform darwin 8 {
+    configure.cflags-append \
+                    -Wno-error=format
+}


### PR DESCRIPTION
There's something funky about size_t causing errors, but at least in most cases they are errors that can be downgraded to warnings trivially. Gcc10 likely wouldn't error on a lot of this code, but adding some cflags is a small price to pay for a more modern gcc