### PR TITLE
libfeedback: fix Tiger build

### DIFF
--- a/gnome/libfeedback/Portfile
+++ b/gnome/libfeedback/Portfile
@@ -39,3 +39,8 @@ configure.args-append \
                     -Dtests=false \
                     -Dudev=false \
                     -Dvapi=true
+
+platform darwin 8 {
+    configure.ldflags-append \
+                    -lssp
+}


### PR DESCRIPTION
___stack_chk_fail linking error. Any of the usual fixes I'm sure would work, I just went with -lssp this time