### PR TITLE
imgui: add Dear ImGui port

### DIFF
--- a/devel/imgui/Portfile
+++ b/devel/imgui/Portfile
@@ -1,0 +1,88 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+
+github.setup        ocornut imgui 1.92.8 v
+revision            0
+categories          devel graphics
+license             MIT
+maintainers         nomaintainer
+
+description         Bloat-free graphical user interface library for C++
+long_description    Dear ImGui is a fast, portable, renderer-agnostic, \
+                    immediate-mode graphical user interface library for C++. \
+                    This port installs a static core library plus the upstream \
+                    headers, backends, examples, fonts, and misc integration \
+                    sources for applications to compile their selected platform \
+                    and renderer backends.
+
+homepage            https://github.com/ocornut/imgui
+
+checksums           rmd160  c2a0f9a38f1df753aef100a71679a051dc47021c \
+                    sha256  fecb33d33930e12ff53a34064e9d3a06c8f7c3e04408f14cd36c80e3faac863b \
+                    size    2081526
+github.tarball_from archive
+
+patchfiles          patch-imgui-big-endian-col32.diff
+
+use_configure       no
+
+compiler.cxx_standard \
+                    2011
+
+set core_sources    {imgui.cpp imgui_draw.cpp imgui_tables.cpp imgui_widgets.cpp}
+
+build {
+    foreach source ${core_sources} {
+        set object [string map {.cpp .o} ${source}]
+        system -W ${worksrcpath} "${configure.cxx} ${configure.cppflags} ${configure.cxxflags} ${configure.cxx_archflags} -I${worksrcpath} -c ${source} -o ${object}"
+    }
+    system -W ${worksrcpath} "ar cr libimgui.a imgui.o imgui_draw.o imgui_tables.o imgui_widgets.o"
+    system -W ${worksrcpath} "ranlib libimgui.a"
+}
+
+destroot {
+    set incdir ${destroot}${prefix}/include/imgui
+    set sharedir ${destroot}${prefix}/share/imgui
+    set docdir ${destroot}${prefix}/share/doc/${name}
+
+    xinstall -d ${incdir} ${incdir}/backends ${incdir}/misc/cpp ${sharedir} \
+        ${destroot}${prefix}/lib/pkgconfig ${docdir}
+
+    xinstall -m 0644 -W ${worksrcpath} \
+        imconfig.h imgui.h imgui_internal.h imstb_rectpack.h imstb_textedit.h \
+        imstb_truetype.h ${incdir}
+
+    xinstall -m 0644 {*}[glob ${worksrcpath}/backends/*.h] ${incdir}/backends
+    xinstall -m 0644 ${worksrcpath}/misc/cpp/imgui_stdlib.h ${incdir}/misc/cpp
+
+    xinstall -m 0644 ${worksrcpath}/libimgui.a ${destroot}${prefix}/lib
+
+    xinstall -m 0644 -W ${worksrcpath} \
+        imgui.cpp imgui_draw.cpp imgui_tables.cpp imgui_widgets.cpp imgui_demo.cpp \
+        ${sharedir}
+    copy ${worksrcpath}/backends ${sharedir}
+    copy ${worksrcpath}/examples ${sharedir}
+    copy ${worksrcpath}/misc ${sharedir}
+
+    xinstall -m 0644 -W ${worksrcpath} LICENSE.txt docs/README.md docs/FAQ.md \
+        docs/BACKENDS.md docs/FONTS.md docs/CHANGELOG.txt ${docdir}
+
+    set pcfile [open ${destroot}${prefix}/lib/pkgconfig/imgui.pc w]
+    puts ${pcfile} "prefix=${prefix}"
+    puts ${pcfile} "exec_prefix=\${prefix}"
+    puts ${pcfile} "libdir=\${exec_prefix}/lib"
+    puts ${pcfile} "includedir=\${prefix}/include"
+    puts ${pcfile} ""
+    puts ${pcfile} "Name: imgui"
+    puts ${pcfile} "Description: Dear ImGui immediate-mode graphical user interface library"
+    puts ${pcfile} "Version: ${version}"
+    puts ${pcfile} "Libs: -L\${libdir} -limgui"
+    puts ${pcfile} "Cflags: -I\${includedir}/imgui -I\${includedir}/imgui/backends"
+    close ${pcfile}
+}
+
+livecheck.type      regex
+livecheck.url       https://github.com/ocornut/imgui/releases
+livecheck.regex     {v([0-9.]+)}

--- a/devel/imgui/files/patch-imgui-big-endian-col32.diff
+++ b/devel/imgui/files/patch-imgui-big-endian-col32.diff
@@ -1,0 +1,18 @@
+--- imgui.h.orig	2026-05-12 14:53:37.000000000 -0600
++++ imgui.h	2026-06-15 00:00:00.000000000 -0600
+@@ -2949,7 +2949,15 @@
+ #define IM_COL32_G_SHIFT    8
+ #define IM_COL32_B_SHIFT    0
+ #define IM_COL32_A_SHIFT    24
+ #define IM_COL32_A_MASK     0xFF000000
++#elif defined(__BIG_ENDIAN__) || defined(__POWERPC__) || defined(__powerpc__) || defined(__ppc__) || (defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
++// OpenGL backends pass ImDrawVert::col and RGBA32 texture data to OpenGL as
++// byte arrays. Keep the in-memory byte order as RGBA on big-endian targets.
++#define IM_COL32_R_SHIFT    24
++#define IM_COL32_G_SHIFT    16
++#define IM_COL32_B_SHIFT    8
++#define IM_COL32_A_SHIFT    0
++#define IM_COL32_A_MASK     0x000000FF
+ #else
+ #define IM_COL32_R_SHIFT    0
+ #define IM_COL32_G_SHIFT    8


### PR DESCRIPTION
Add a new imgui port for Dear ImGui 1.92.8. The port builds and installs the core static library, public headers, SDL2/OpenGL 2 backend sources, examples and docs.

It includes a PowerPC/big endian color packing patch needed by the OpenGL2 backend, which consumes ImDrawVert colors and RGBA32 font texture data as raw RGBA bytes.
