### PR TITLE
youtube-viewer: allow other mpv ports to satisfy dependency.

### DIFF
--- a/multimedia/youtube-viewer/Portfile
+++ b/multimedia/youtube-viewer/Portfile
@@ -56,7 +56,7 @@ depends_lib-append \
     port:p${perl5.major}-text-tabsxwrap \
     port:p${perl5.major}-uri
 depends_run-append \
-    port:mpv \
+    path:bin/mpv:mpv \
     port:p${perl5.major}-common-sense \
     port:p${perl5.major}-mozilla-ca
 


### PR DESCRIPTION
This change allows ports like mpv-legacy to satisfy the dependency.