### PR TITLE
ffmpeg8: remove opencolorio as a default variant on Tiger

### DIFF
--- a/multimedia/ffmpeg8/Portfile
+++ b/multimedia/ffmpeg8/Portfile
@@ -320,8 +320,6 @@ platform darwin {
 
         configure.args-append \
                     --disable-asm
-
-        default_variants-append -opencolorio
     }
 }
 
@@ -579,7 +577,11 @@ variant x11 {
 
 # The old ffmpeg port was GPL-2+ as base and had a no_gpl variant, so this keeps us consistent
 # Also, -gpl2 causes other ports to fail to build due to the missing libpostproc (#35473)
-default_variants-append +gpl2 +opencolorio +vmaf
+default_variants-append +gpl2 +vmaf
+
+if {${os.platform} eq "darwin" && ${os.major} > 8} {
+    default_variants-append +opencolorio
+}
 
 # ppc64 can only be built on a G5, so default to that.
 if {${os.platform} eq "darwin" && ${configure.build_arch} eq "ppc64"} {

--- a/multimedia/ffmpeg8/Portfile
+++ b/multimedia/ffmpeg8/Portfile
@@ -320,6 +320,8 @@ platform darwin {
 
         configure.args-append \
                     --disable-asm
+
+        default_variants-append -opencolorio
     }
 }
 


### PR DESCRIPTION
Fixes circular dependency, and I don't recall opencolorio building anyway. If someone fixes opencolorio, adding the variant back in is trivial.