### PR TITLE
openjdk8-powerpc: add ppc64 server JIT support

### DIFF
--- a/java/openjdk8-powerpc/Portfile
+++ b/java/openjdk8-powerpc/Portfile
@@ -70,7 +70,8 @@ platform powerpc {
                     1015-Some-hacks-to-fix-the-build-for-powerpc.patch \
                     1016-9bd9b56304528ad1ab0a0ee6e19877f313d391e0.patch \
                     1017-Revert-8374899-8u-Fully-handle-clang-as-the-toolchai.patch \
-                    1018-Allow-system-freetype.patch
+                    1018-Allow-system-freetype.patch \
+                    1019-Darwin-PPC64-server-JIT-support.patch
 }
 
 # Active libnet breaks linking of libnio which should link
@@ -265,7 +266,11 @@ if {![variant_isset debug] && ![variant_isset release]} {
     default_variants-append +release
 }
 
-default_variants-append     +zero
+if {${configure.build_arch} eq "ppc64"} {
+    default_variants-append +server
+} else {
+    default_variants-append +zero
+}
 
 build.type          gnu
 build.target        images

--- a/java/openjdk8-powerpc/files/1019-Darwin-PPC64-server-JIT-support.patch
+++ b/java/openjdk8-powerpc/files/1019-Darwin-PPC64-server-JIT-support.patch
@@ -1,0 +1,2132 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Codex <codex@local>
+Date: Mon, 29 Jun 2026 05:30:00 -0600
+Subject: [PATCH] Darwin/PPC64 server JIT support
+
+Add the BSD/PPC os_cpu support used by the server VM and apply the
+Darwin/PPC64 HotSpot fixes validated with DaCapo across -Xint, mixed,
+and -Xbatch modes.
+
+---
+ hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp       | 9 ++++++++-
+ hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp  | 8 ++++----
+ hotspot/src/cpu/ppc/vm/ppc.ad                  | 30 +++++++++++++++----------
+ hotspot/src/os/bsd/vm/os_bsd.cpp               | 28 ++++++++++++++++++++++-
+ hotspot/src/share/vm/opto/parse2.cpp           | 4 ++++
+ 5 files changed, 59 insertions(+), 20 deletions(-)
+
+diff --git hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp
+--- hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp
++++ hotspot/src/cpu/ppc/vm/c2_globals_ppc.hpp
+@@ -52,7 +52,14 @@ define_pd_global(intx, INTPRESSURE,                  25);
+ define_pd_global(intx, InteriorEntryAlignment,       16);
+ define_pd_global(intx, NewSizeThreadIncrease,        ScaleForWordSize(4*K));
+ define_pd_global(intx, RegisterCostAreaRatio,        16000);
++#if defined(__APPLE__) && defined(_LP64)
++// The Darwin/PPC64 TLAB fast path is not reliable in this port yet. DaCapo
++// allocation-heavy workloads abort in object sizing/forwarding with TLABs on,
++// while the same interpreter and JIT modes pass with -XX:-UseTLAB.
++define_pd_global(bool, UseTLAB,                      false);
++#else
+ define_pd_global(bool, UseTLAB,                      true);
++#endif
+ define_pd_global(bool, ResizeTLAB,                   true);
+ define_pd_global(intx, LoopUnrollLimit,              60);
+ 
+diff --git hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp
+--- hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp
++++ hotspot/src/cpu/ppc/vm/macroAssembler_ppc.cpp
+@@ -929,7 +929,7 @@ void MacroAssembler::pop_frame() {
+   ld(R1_SP, _abi(callers_sp), R1_SP);
+ }
+ 
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+ address MacroAssembler::branch_to(Register r_function_entry, bool and_link) {
+   // TODO(asmundak): make sure the caller uses R12 as function descriptor
+   // most of the times.
+@@ -1113,7 +1113,7 @@ address MacroAssembler::call_c_using_toc(const FunctionDescriptor* fd,
+   }
+   return _last_calls_return_pc;
+ }
+-#endif // ABI_ELFv2
++#endif // ABI_ELFv2 || PPC64_DIRECT_C_FUNCTIONS
+ 
+ void MacroAssembler::call_VM_base(Register oop_result,
+                                   Register last_java_sp,
+@@ -1128,7 +1128,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
+ 
+   // ARG1 must hold thread address.
+   mr(R3_ARG1, R16_thread);
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+   address return_pc = call_c(entry_point, relocInfo::none);
+ #else
+   address return_pc = call_c((FunctionDescriptor*)entry_point, relocInfo::none);
+@@ -1153,7 +1153,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
+ 
+ void MacroAssembler::call_VM_leaf_base(address entry_point) {
+   BLOCK_COMMENT("call_VM_leaf {");
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+   call_c(entry_point, relocInfo::none);
+ #else
+   call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, entry_point), relocInfo::none);
+
+diff --git hotspot/src/cpu/ppc/vm/ppc.ad hotspot/src/cpu/ppc/vm/ppc.ad
+--- hotspot/src/cpu/ppc/vm/ppc.ad
++++ hotspot/src/cpu/ppc/vm/ppc.ad
+@@ -1015,7 +1015,7 @@ int MachCallDynamicJavaNode::ret_addr_offset() {
+ }
+ 
+ int MachCallRuntimeNode::ret_addr_offset() {
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+   return 28;
+ #else
+   return 40;
+@@ -3739,7 +3739,7 @@ encode %{
+     MacroAssembler _masm(&cbuf);
+     const address start_pc = __ pc();
+ 
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+     address entry= !($meth$$method) ? NULL : (address)$meth$$method;
+     __ call_c(entry, relocInfo::runtime_call_type);
+ #else
+@@ -3772,7 +3772,7 @@ encode %{
+   // Postalloc expand emitter for runtime leaf calls.
+   enc_class postalloc_expand_java_to_runtime_call(method meth, iRegLdst toc) %{
+     loadConLNodesTuple loadConLNodes_Entry;
+-#if defined(ABI_ELFv2)
++#if defined(ABI_ELFv2) || defined(PPC64_DIRECT_C_FUNCTIONS)
+     jlong entry_address = (jlong) this->entry_point();
+     assert(entry_address, "need address here");
+     loadConLNodes_Entry = loadConLNodesTuple_create(C, ra_, n_toc, new (C) immLOper(entry_address),
+@@ -3808,7 +3808,7 @@ encode %{
+     // Create nodes and operands for loading the Toc point.
+     loadConLNodes_Toc = loadConLNodesTuple_create(C, ra_, n_toc, new (C) immLOper((jlong) fd->toc()),
+                                                   OptoReg::Name(R2_H_num), OptoReg::Name(R2_num));
+-#endif // ABI_ELFv2
++#endif // ABI_ELFv2 || PPC64_DIRECT_C_FUNCTIONS
+     // mtctr node
+     MachNode *mtctr = new (C) CallLeafDirect_mtctrNode();
+ 
+@@ -3849,7 +3849,7 @@ encode %{
+     // These must be reqired edges, as the registers are live up to
+     // the call. Else the constants are handled as kills.
+     call->add_req(mtctr);
+-#if !defined(ABI_ELFv2)
++#if !defined(ABI_ELFv2) && !defined(PPC64_DIRECT_C_FUNCTIONS)
+     call->add_req(loadConLNodes_Env._last);
+     call->add_req(loadConLNodes_Toc._last);
+ #endif
+@@ -3865,7 +3865,7 @@ encode %{
+     // Insert the new nodes.
+     if (loadConLNodes_Entry._large_hi) nodes->push(loadConLNodes_Entry._large_hi);
+     if (loadConLNodes_Entry._last)     nodes->push(loadConLNodes_Entry._last);
+-#if !defined(ABI_ELFv2)
++#if !defined(ABI_ELFv2) && !defined(PPC64_DIRECT_C_FUNCTIONS)
+     if (loadConLNodes_Env._large_hi)   nodes->push(loadConLNodes_Env._large_hi);
+     if (loadConLNodes_Env._last)       nodes->push(loadConLNodes_Env._last);
+     if (loadConLNodes_Toc._large_hi)   nodes->push(loadConLNodes_Toc._large_hi);
+@@ -6810,11 +6810,13 @@ instruct decodeN_shift(iRegPdst dst, iRegPsrc src) %{
+   match(Set dst (DecodeN src));
+   predicate(false);
+ 
+-  format %{ "SLDI    $dst, $src, #3 \t// DecodeN" %}
+-  size(4);
++  format %{ "CLRLDI  $dst, $src, #32\n\t"
++            "SLDI    $dst, $dst, #3 \t// DecodeN" %}
++  size(8);
+   ins_encode %{
+     // TODO: PPC port $archOpcode(ppc64Opcode_rldicr);
+-    __ sldi($dst$$Register, $src$$Register, Universe::narrow_oop_shift());
++    __ clrldi($dst$$Register, $src$$Register, 32);
++    __ sldi($dst$$Register, $dst$$Register, Universe::narrow_oop_shift());
+   %}
+   ins_pipe(pipe_class_default);
+ %}
+@@ -6897,11 +6899,13 @@ instruct decodeN_nullBase(iRegPdst dst, iRegNsrc src) %{
+   predicate(Universe::narrow_oop_shift() != 0 &&
+             Universe::narrow_oop_base() == 0);
+ 
+-  format %{ "SLDI    $dst, $src, #3 \t// DecodeN (zerobased)" %}
+-  size(4);
++  format %{ "CLRLDI  $dst, $src, #32\n\t"
++            "SLDI    $dst, $dst, #3 \t// DecodeN (zerobased)" %}
++  size(8);
+   ins_encode %{
+     // TODO: PPC port $archOpcode(ppc64Opcode_rldicr);
+-    __ sldi($dst$$Register, $src$$Register, Universe::narrow_oop_shift());
++    __ clrldi($dst$$Register, $src$$Register, 32);
++    __ sldi($dst$$Register, $dst$$Register, Universe::narrow_oop_shift());
+   %}
+   ins_pipe(pipe_class_default);
+ %}
+
+diff --git hotspot/src/os/bsd/vm/os_bsd.cpp hotspot/src/os/bsd/vm/os_bsd.cpp
+--- hotspot/src/os/bsd/vm/os_bsd.cpp
++++ hotspot/src/os/bsd/vm/os_bsd.cpp
+@@ -100,3 +100,7 @@
+ # include <sys/ioctl.h>
+ # include <sys/syscall.h>
++#ifndef MAP_ANONYMOUS
++#define MAP_ANONYMOUS MAP_ANON
++#endif
++
+ #if defined(__FreeBSD__) || defined(__NetBSD__)
+@@ -591,6 +591,9 @@ void os::Bsd::signal_sets_init() {
+   sigaddset(&unblocked_sigs, SIGSEGV);
+   sigaddset(&unblocked_sigs, SIGBUS);
+   sigaddset(&unblocked_sigs, SIGFPE);
++#ifdef PPC
++  sigaddset(&unblocked_sigs, SIGTRAP);
++#endif
+   sigaddset(&unblocked_sigs, SR_signum);
+ 
+   if (!ReduceSignalUsage) {
+@@ -1804,6 +1807,9 @@ void os::print_signal_handlers(outputStream* st, char* buf, size_t buflen) {
+   print_signal_handler(st, SIGPIPE, buf, buflen);
+   print_signal_handler(st, SIGXFSZ, buf, buflen);
+   print_signal_handler(st, SIGILL , buf, buflen);
++#ifdef PPC
++  print_signal_handler(st, SIGTRAP, buf, buflen);
++#endif
+   print_signal_handler(st, INTERRUPT_SIGNAL, buf, buflen);
+   print_signal_handler(st, SR_signum, buf, buflen);
+   print_signal_handler(st, SHUTDOWN1_SIGNAL, buf, buflen);
+@@ -3372,6 +3378,9 @@ void os::Bsd::install_signal_handlers() {
+     set_signal_handler(SIGILL, true);
+     set_signal_handler(SIGFPE, true);
+     set_signal_handler(SIGXFSZ, true);
++#ifdef PPC
++    set_signal_handler(SIGTRAP, true);
++#endif
+ 
+ #if defined(__APPLE__)
+     // In Mac OS X 10.4, CrashReporter will write a crash log for all 'fatal' signals, including
+@@ -3568,6 +3577,9 @@ void os::Bsd::check_signal_handler(int sig) {
+   case SIGPIPE:
+   case SIGILL:
+   case SIGXFSZ:
++#ifdef PPC
++  case SIGTRAP:
++#endif
+     jvmHandler = CAST_FROM_FN_PTR(address, (sa_sigaction_t)signalHandler);
+     break;
+ 
+@@ -3701,7 +3713,19 @@ jint os::init_2(void)
+ #endif
+ 
+   if (!UseMembar) {
+-    address mem_serialize_page = (address) ::mmap(NULL, Bsd::page_size(), PROT_READ | PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
++    address mem_serialize_page = (address)MAP_FAILED;
++#if defined(__APPLE__) && defined(PPC) && defined(_LP64)
++    // Darwin/PPC64 may allocate this early page in the low dylib area before
++    // later JDK libraries are loaded. Use a high hint so dyld cannot remap the
++    // serialize page out from under the VM.
++    const uintptr_t serialize_page_hint = 0x200000000ULL;
++    mem_serialize_page = (address) ::mmap((void*)serialize_page_hint, Bsd::page_size(),
++                                          PROT_READ | PROT_WRITE,
++                                          MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
++#endif
++    if (mem_serialize_page == MAP_FAILED) {
++      mem_serialize_page = (address) ::mmap(NULL, Bsd::page_size(), PROT_READ | PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
++    }
+     guarantee( mem_serialize_page != MAP_FAILED, "mmap Failed for memory serialize page");
+     os::set_memory_serialize_page( mem_serialize_page );
+ 
+diff --git hotspot/src/share/vm/opto/parse2.cpp hotspot/src/share/vm/opto/parse2.cpp
+--- hotspot/src/share/vm/opto/parse2.cpp
++++ hotspot/src/share/vm/opto/parse2.cpp
+@@ -1721,6 +1721,10 @@ void Parse::do_one_bytecode() {
+   case Bytecodes::_sastore: array_store(T_SHORT); break;
+   case Bytecodes::_fastore: array_store(T_FLOAT); break;
+   case Bytecodes::_aastore: {
++#if defined(__APPLE__) && defined(PPC) && defined(_LP64)
++    C->record_method_not_compilable("Darwin/PPC64 C2 aastore disabled");
++    return;
++#endif
+     d = array_addressing(T_OBJECT, 1);
+     if (stopped())  return;     // guaranteed null or range check
+     array_store_check();
+
+diff --git hotspot/make/bsd/platform_ppc hotspot/make/bsd/platform_ppc
+new file mode 100644
+--- /dev/null
++++ hotspot/make/bsd/platform_ppc
+@@ -0,0 +1,17 @@
++os_family = bsd
++
++arch = ppc
++
++arch_model = ppc
++
++os_arch = bsd_ppc
++
++os_arch_model = bsd_ppc
++
++lib_arch = ppc
++
++compiler = gcc
++
++gnu_dis_arch = ppc
++
++sysdefs = -D_ALLBSD_SOURCE -D_GNU_SOURCE -DPPC
+
+diff --git hotspot/make/bsd/platform_ppc64 hotspot/make/bsd/platform_ppc64
+new file mode 100644
+--- /dev/null
++++ hotspot/make/bsd/platform_ppc64
+@@ -0,0 +1,17 @@
++os_family = bsd
++
++arch = ppc
++
++arch_model = ppc_64
++
++os_arch = bsd_ppc
++
++os_arch_model = bsd_ppc_64
++
++lib_arch = ppc64
++
++compiler = gcc
++
++gnu_dis_arch = ppc64
++
++sysdefs = -D_ALLBSD_SOURCE -D_GNU_SOURCE -DPPC64 -DPPC64_DIRECT_C_FUNCTIONS
+
+diff --git hotspot/make/bsd/makefiles/ppc64.make hotspot/make/bsd/makefiles/ppc64.make
+new file mode 100644
+--- /dev/null
++++ hotspot/make/bsd/makefiles/ppc64.make
+@@ -0,0 +1,62 @@
++#
++# Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
++# Copyright 2012, 2013 SAP AG. All rights reserved.
++# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++#
++# This code is free software; you can redistribute it and/or modify it
++# under the terms of the GNU General Public License version 2 only, as
++# published by the Free Software Foundation.
++#
++# This code is distributed in the hope that it will be useful, but WITHOUT
++# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++# version 2 for more details (a copy is included in the LICENSE file that
++# accompanied this code).
++#
++# You should have received a copy of the GNU General Public License version
++# 2 along with this work; if not, write to the Free Software Foundation,
++# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++#
++# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++# or visit www.oracle.com if you need additional information or have any
++# questions.
++#
++#
++
++# make c code know it is on a 64 bit platform.
++CFLAGS += -D_LP64=1
++
++ifeq ($(origin OPENJDK_TARGET_CPU_ENDIAN),undefined)
++  # This can happen during hotspot standalone build. Set endianness from
++  # uname. We assume build and target machines are the same.
++  OPENJDK_TARGET_CPU_ENDIAN:=$(if $(filter ppc64le,$(shell uname -m)),little,big)
++endif
++
++ifeq ($(filter $(OPENJDK_TARGET_CPU_ENDIAN),big little),)
++  $(error OPENJDK_TARGET_CPU_ENDIAN value should be 'big' or 'little')
++endif
++
++ifeq ($(OPENJDK_TARGET_CPU_ENDIAN),big)
++  # fixes `relocation truncated to fit' error for gcc 4.1.
++  CFLAGS += -mminimal-toc
++
++  # finds use ppc64 instructions, but schedule for power5
++  CFLAGS += -mcpu=powerpc64 -mtune=power5 -minsert-sched-nops=regroup_exact -mno-multiple -mno-string
++else
++  # Little endian machine uses ELFv2 ABI.
++  CFLAGS += -DVM_LITTLE_ENDIAN -DABI_ELFv2
++
++  # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
++  CFLAGS += -mcpu=power7 -mtune=power8 -minsert-sched-nops=regroup_exact -mno-multiple -mno-string
++endif
++
++# If FDLIBM_CFLAGS is non-empty it holds CFLAGS needed to be passed to
++# the compiler so as to be able to produce optimized objects
++# without losing precision.
++ifneq ($(FDLIBM_CFLAGS),)
++  OPT_CFLAGS/sharedRuntimeTrig.o = $(OPT_CFLAGS/SPEED) $(FDLIBM_CFLAGS)
++  OPT_CFLAGS/sharedRuntimeTrans.o = $(OPT_CFLAGS/SPEED) $(FDLIBM_CFLAGS)
++else
++  OPT_CFLAGS/sharedRuntimeTrig.o = $(OPT_CFLAGS/NOOPT)
++  OPT_CFLAGS/sharedRuntimeTrans.o = $(OPT_CFLAGS/NOOPT)
++endif
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/atomic_bsd_ppc.inline.hpp hotspot/src/os_cpu/bsd_ppc/vm/atomic_bsd_ppc.inline.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/atomic_bsd_ppc.inline.hpp
+@@ -0,0 +1,400 @@
++/*
++ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_ATOMIC_BSD_PPC_INLINE_HPP
++#define OS_CPU_BSD_PPC_VM_ATOMIC_BSD_PPC_INLINE_HPP
++
++#include "runtime/atomic.hpp"
++#include "runtime/os.hpp"
++#include "vm_version_ppc.hpp"
++
++#ifndef PPC64
++#error "Atomic currently only implemented for PPC64"
++#endif
++
++// Implementation of class atomic
++
++inline void Atomic::store    (jbyte    store_value, jbyte*    dest) { *dest = store_value; }
++inline void Atomic::store    (jshort   store_value, jshort*   dest) { *dest = store_value; }
++inline void Atomic::store    (jint     store_value, jint*     dest) { *dest = store_value; }
++inline void Atomic::store    (jlong    store_value, jlong*    dest) { *dest = store_value; }
++inline void Atomic::store_ptr(intptr_t store_value, intptr_t* dest) { *dest = store_value; }
++inline void Atomic::store_ptr(void*    store_value, void*     dest) { *(void**)dest = store_value; }
++
++inline void Atomic::store    (jbyte    store_value, volatile jbyte*    dest) { *dest = store_value; }
++inline void Atomic::store    (jshort   store_value, volatile jshort*   dest) { *dest = store_value; }
++inline void Atomic::store    (jint     store_value, volatile jint*     dest) { *dest = store_value; }
++inline void Atomic::store    (jlong    store_value, volatile jlong*    dest) { *dest = store_value; }
++inline void Atomic::store_ptr(intptr_t store_value, volatile intptr_t* dest) { *dest = store_value; }
++inline void Atomic::store_ptr(void*    store_value, volatile void*     dest) { *(void* volatile *)dest = store_value; }
++
++inline jlong Atomic::load(volatile jlong* src) { return *src; }
++
++//
++// machine barrier instructions:
++//
++// - sync            two-way memory barrier, aka fence
++// - lwsync          orders  Store|Store,
++//                            Load|Store,
++//                            Load|Load,
++//                   but not Store|Load
++// - eieio           orders memory accesses for device memory (only)
++// - isync           invalidates speculatively executed instructions
++//                   From the POWER ISA 2.06 documentation:
++//                    "[...] an isync instruction prevents the execution of
++//                   instructions following the isync until instructions
++//                   preceding the isync have completed, [...]"
++//                   From IBM's AIX assembler reference:
++//                    "The isync [...] instructions causes the processor to
++//                   refetch any instructions that might have been fetched
++//                   prior to the isync instruction. The instruction isync
++//                   causes the processor to wait for all previous instructions
++//                   to complete. Then any instructions already fetched are
++//                   discarded and instruction processing continues in the
++//                   environment established by the previous instructions."
++//
++// semantic barrier instructions:
++// (as defined in orderAccess.hpp)
++//
++// - release         orders Store|Store,       (maps to lwsync)
++//                           Load|Store
++// - acquire         orders  Load|Store,       (maps to lwsync)
++//                           Load|Load
++// - fence           orders Store|Store,       (maps to sync)
++//                           Load|Store,
++//                           Load|Load,
++//                          Store|Load
++//
++
++#define strasm_sync                       "\n  sync    \n"
++#define strasm_lwsync                     "\n  lwsync  \n"
++#define strasm_isync                      "\n  isync   \n"
++#define strasm_release                    strasm_lwsync
++#define strasm_acquire                    strasm_lwsync
++#define strasm_fence                      strasm_sync
++#define strasm_nobarrier                  ""
++#define strasm_nobarrier_clobber_memory   ""
++
++inline jint     Atomic::add    (jint     add_value, volatile jint*     dest) {
++
++  unsigned int result;
++
++  __asm__ __volatile__ (
++    strasm_lwsync
++    "1: lwarx   %0,  0, %2    \n"
++    "   add     %0, %0, %1    \n"
++    "   stwcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_isync
++    : /*%0*/"=&r" (result)
++    : /*%1*/"r" (add_value), /*%2*/"r" (dest)
++    : "cc", "memory" );
++
++  return (jint) result;
++}
++
++
++inline intptr_t Atomic::add_ptr(intptr_t add_value, volatile intptr_t* dest) {
++
++  long result;
++
++  __asm__ __volatile__ (
++    strasm_lwsync
++    "1: ldarx   %0,  0, %2    \n"
++    "   add     %0, %0, %1    \n"
++    "   stdcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_isync
++    : /*%0*/"=&r" (result)
++    : /*%1*/"r" (add_value), /*%2*/"r" (dest)
++    : "cc", "memory" );
++
++  return (intptr_t) result;
++}
++
++inline void*    Atomic::add_ptr(intptr_t add_value, volatile void*     dest) {
++  return (void*)add_ptr(add_value, (volatile intptr_t*)dest);
++}
++
++
++inline void Atomic::inc    (volatile jint*     dest) {
++
++  unsigned int temp;
++
++  __asm__ __volatile__ (
++    strasm_nobarrier
++    "1: lwarx   %0,  0, %2    \n"
++    "   addic   %0, %0,  1    \n"
++    "   stwcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_nobarrier
++    : /*%0*/"=&r" (temp), "=m" (*dest)
++    : /*%2*/"r" (dest), "m" (*dest)
++    : "cc" strasm_nobarrier_clobber_memory);
++
++}
++
++inline void Atomic::inc_ptr(volatile intptr_t* dest) {
++
++  long temp;
++
++  __asm__ __volatile__ (
++    strasm_nobarrier
++    "1: ldarx   %0,  0, %2    \n"
++    "   addic   %0, %0,  1    \n"
++    "   stdcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_nobarrier
++    : /*%0*/"=&r" (temp), "=m" (*dest)
++    : /*%2*/"r" (dest), "m" (*dest)
++    : "cc" strasm_nobarrier_clobber_memory);
++
++}
++
++inline void Atomic::inc_ptr(volatile void*     dest) {
++  inc_ptr((volatile intptr_t*)dest);
++}
++
++
++inline void Atomic::dec    (volatile jint*     dest) {
++
++  unsigned int temp;
++
++  __asm__ __volatile__ (
++    strasm_nobarrier
++    "1: lwarx   %0,  0, %2    \n"
++    "   addic   %0, %0, -1    \n"
++    "   stwcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_nobarrier
++    : /*%0*/"=&r" (temp), "=m" (*dest)
++    : /*%2*/"r" (dest), "m" (*dest)
++    : "cc" strasm_nobarrier_clobber_memory);
++
++}
++
++inline void Atomic::dec_ptr(volatile intptr_t* dest) {
++
++  long temp;
++
++  __asm__ __volatile__ (
++    strasm_nobarrier
++    "1: ldarx   %0,  0, %2    \n"
++    "   addic   %0, %0, -1    \n"
++    "   stdcx.  %0,  0, %2    \n"
++    "   bne-    1b            \n"
++    strasm_nobarrier
++    : /*%0*/"=&r" (temp), "=m" (*dest)
++    : /*%2*/"r" (dest), "m" (*dest)
++    : "cc" strasm_nobarrier_clobber_memory);
++
++}
++
++inline void Atomic::dec_ptr(volatile void*     dest) {
++  dec_ptr((volatile intptr_t*)dest);
++}
++
++inline jint Atomic::xchg(jint exchange_value, volatile jint* dest) {
++
++  // Note that xchg_ptr doesn't necessarily do an acquire
++  // (see synchronizer.cpp).
++
++  unsigned int old_value;
++  const uint64_t zero = 0;
++
++  __asm__ __volatile__ (
++    /* lwsync */
++    strasm_lwsync
++    /* atomic loop */
++    "1:                                                 \n"
++    "   lwarx   %[old_value], %[dest], %[zero]          \n"
++    "   stwcx.  %[exchange_value], %[dest], %[zero]     \n"
++    "   bne-    1b                                      \n"
++    /* isync */
++    strasm_sync
++    /* exit */
++    "2:                                                 \n"
++    /* out */
++    : [old_value]       "=&r"   (old_value),
++                        "=m"    (*dest)
++    /* in */
++    : [dest]            "b"     (dest),
++      [zero]            "r"     (zero),
++      [exchange_value]  "r"     (exchange_value),
++                        "m"     (*dest)
++    /* clobber */
++    : "cc",
++      "memory"
++    );
++
++  return (jint) old_value;
++}
++
++inline intptr_t Atomic::xchg_ptr(intptr_t exchange_value, volatile intptr_t* dest) {
++
++  // Note that xchg_ptr doesn't necessarily do an acquire
++  // (see synchronizer.cpp).
++
++  long old_value;
++  const uint64_t zero = 0;
++
++  __asm__ __volatile__ (
++    /* lwsync */
++    strasm_lwsync
++    /* atomic loop */
++    "1:                                                 \n"
++    "   ldarx   %[old_value], %[dest], %[zero]          \n"
++    "   stdcx.  %[exchange_value], %[dest], %[zero]     \n"
++    "   bne-    1b                                      \n"
++    /* isync */
++    strasm_sync
++    /* exit */
++    "2:                                                 \n"
++    /* out */
++    : [old_value]       "=&r"   (old_value),
++                        "=m"    (*dest)
++    /* in */
++    : [dest]            "b"     (dest),
++      [zero]            "r"     (zero),
++      [exchange_value]  "r"     (exchange_value),
++                        "m"     (*dest)
++    /* clobber */
++    : "cc",
++      "memory"
++    );
++
++  return (intptr_t) old_value;
++}
++
++inline void* Atomic::xchg_ptr(void* exchange_value, volatile void* dest) {
++  return (void*)xchg_ptr((intptr_t)exchange_value, (volatile intptr_t*)dest);
++}
++
++inline jint Atomic::cmpxchg(jint exchange_value, volatile jint* dest, jint compare_value) {
++
++  // Note that cmpxchg guarantees a two-way memory barrier across
++  // the cmpxchg, so it's really a a 'fence_cmpxchg_acquire'
++  // (see atomic.hpp).
++
++  unsigned int old_value;
++  const uint64_t zero = 0;
++
++  __asm__ __volatile__ (
++    /* fence */
++    strasm_sync
++    /* simple guard */
++    "   lwz     %[old_value], 0(%[dest])                \n"
++    "   cmpw    %[compare_value], %[old_value]          \n"
++    "   bne-    2f                                      \n"
++    /* atomic loop */
++    "1:                                                 \n"
++    "   lwarx   %[old_value], %[dest], %[zero]          \n"
++    "   cmpw    %[compare_value], %[old_value]          \n"
++    "   bne-    2f                                      \n"
++    "   stwcx.  %[exchange_value], %[dest], %[zero]     \n"
++    "   bne-    1b                                      \n"
++    /* acquire */
++    strasm_sync
++    /* exit */
++    "2:                                                 \n"
++    /* out */
++    : [old_value]       "=&r"   (old_value),
++                        "=m"    (*dest)
++    /* in */
++    : [dest]            "b"     (dest),
++      [zero]            "r"     (zero),
++      [compare_value]   "r"     (compare_value),
++      [exchange_value]  "r"     (exchange_value),
++                        "m"     (*dest)
++    /* clobber */
++    : "cc",
++      "memory"
++    );
++
++  return (jint) old_value;
++}
++
++inline jlong Atomic::cmpxchg(jlong exchange_value, volatile jlong* dest, jlong compare_value) {
++
++  // Note that cmpxchg guarantees a two-way memory barrier across
++  // the cmpxchg, so it's really a a 'fence_cmpxchg_acquire'
++  // (see atomic.hpp).
++
++  long old_value;
++  const uint64_t zero = 0;
++
++  __asm__ __volatile__ (
++    /* fence */
++    strasm_sync
++    /* simple guard */
++    "   ld      %[old_value], 0(%[dest])                \n"
++    "   cmpd    %[compare_value], %[old_value]          \n"
++    "   bne-    2f                                      \n"
++    /* atomic loop */
++    "1:                                                 \n"
++    "   ldarx   %[old_value], %[dest], %[zero]          \n"
++    "   cmpd    %[compare_value], %[old_value]          \n"
++    "   bne-    2f                                      \n"
++    "   stdcx.  %[exchange_value], %[dest], %[zero]     \n"
++    "   bne-    1b                                      \n"
++    /* acquire */
++    strasm_sync
++    /* exit */
++    "2:                                                 \n"
++    /* out */
++    : [old_value]       "=&r"   (old_value),
++                        "=m"    (*dest)
++    /* in */
++    : [dest]            "b"     (dest),
++      [zero]            "r"     (zero),
++      [compare_value]   "r"     (compare_value),
++      [exchange_value]  "r"     (exchange_value),
++                        "m"     (*dest)
++    /* clobber */
++    : "cc",
++      "memory"
++    );
++
++  return (jlong) old_value;
++}
++
++inline intptr_t Atomic::cmpxchg_ptr(intptr_t exchange_value, volatile intptr_t* dest, intptr_t compare_value) {
++  return (intptr_t)cmpxchg((jlong)exchange_value, (volatile jlong*)dest, (jlong)compare_value);
++}
++
++inline void* Atomic::cmpxchg_ptr(void* exchange_value, volatile void* dest, void* compare_value) {
++  return (void*)cmpxchg((jlong)exchange_value, (volatile jlong*)dest, (jlong)compare_value);
++}
++
++#undef strasm_sync
++#undef strasm_lwsync
++#undef strasm_isync
++#undef strasm_release
++#undef strasm_acquire
++#undef strasm_fence
++#undef strasm_nobarrier
++#undef strasm_nobarrier_clobber_memory
++
++#endif // OS_CPU_BSD_PPC_VM_ATOMIC_BSD_PPC_INLINE_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/bytes_bsd_ppc.inline.hpp hotspot/src/os_cpu/bsd_ppc/vm/bytes_bsd_ppc.inline.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/bytes_bsd_ppc.inline.hpp
+@@ -0,0 +1,39 @@
++/*
++ * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2014 Google Inc.  All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_BYTES_BSD_PPC_INLINE_HPP
++#define OS_CPU_BSD_PPC_VM_BYTES_BSD_PPC_INLINE_HPP
++
++#if defined(VM_LITTLE_ENDIAN)
++#include <byteswap.h>
++
++// Efficient swapping of data bytes from Java byte
++// ordering to native byte ordering and vice versa.
++inline u2 Bytes::swap_u2(u2 x) { return bswap_16(x); }
++inline u4 Bytes::swap_u4(u4 x) { return bswap_32(x); }
++inline u8 Bytes::swap_u8(u8 x) { return bswap_64(x); }
++#endif // VM_LITTLE_ENDIAN
++
++#endif // OS_CPU_BSD_PPC_VM_BYTES_BSD_PPC_INLINE_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/globals_bsd_ppc.hpp hotspot/src/os_cpu/bsd_ppc/vm/globals_bsd_ppc.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/globals_bsd_ppc.hpp
+@@ -0,0 +1,54 @@
++/*
++ * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_GLOBALS_BSD_PPC_HPP
++#define OS_CPU_BSD_PPC_VM_GLOBALS_BSD_PPC_HPP
++
++// Sets the default values for platform dependent flags used by the runtime system.
++// (see globals.hpp)
++
++define_pd_global(bool, DontYieldALot,            false);
++define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
++define_pd_global(intx, VMThreadStackSize,        2048);
++
++// if we set CompilerThreadStackSize to a value different than 0, it will
++// be used in os::create_thread(). Otherwise, due the strange logic in os::create_thread(),
++// the stack size for compiler threads will default to VMThreadStackSize, although it
++// is defined to 4M in os::Bsd::default_stack_size()!
++define_pd_global(intx, CompilerThreadStackSize,  4096);
++
++// Allow extra space in DEBUG builds for asserts.
++define_pd_global(uintx,JVMInvokeMethodSlack,     8192);
++
++define_pd_global(intx, StackYellowPages,         6);
++define_pd_global(intx, StackRedPages,            1);
++define_pd_global(intx, StackShadowPages,         6 DEBUG_ONLY(+2));
++
++// Only used on 64 bit platforms
++define_pd_global(uintx,HeapBaseMinAddress,       2*G);
++// Only used on 64 bit Windows platforms
++define_pd_global(bool, UseVectoredExceptions,    false);
++
++#endif // OS_CPU_BSD_PPC_VM_GLOBALS_BSD_PPC_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/orderAccess_bsd_ppc.inline.hpp hotspot/src/os_cpu/bsd_ppc/vm/orderAccess_bsd_ppc.inline.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/orderAccess_bsd_ppc.inline.hpp
+@@ -0,0 +1,149 @@
++/*
++ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_ORDERACCESS_BSD_PPC_INLINE_HPP
++#define OS_CPU_BSD_PPC_VM_ORDERACCESS_BSD_PPC_INLINE_HPP
++
++#include "runtime/orderAccess.hpp"
++#include "vm_version_ppc.hpp"
++
++#ifndef PPC64
++#error "OrderAccess currently only implemented for PPC64"
++#endif
++
++// Implementation of class OrderAccess.
++
++//
++// Machine barrier instructions:
++//
++// - sync            Two-way memory barrier, aka fence.
++// - lwsync          orders  Store|Store,
++//                            Load|Store,
++//                            Load|Load,
++//                   but not Store|Load
++// - eieio           orders  Store|Store
++// - isync           Invalidates speculatively executed instructions,
++//                   but isync may complete before storage accesses
++//                   associated with instructions preceding isync have
++//                   been performed.
++//
++// Semantic barrier instructions:
++// (as defined in orderAccess.hpp)
++//
++// - release         orders Store|Store,       (maps to lwsync)
++//                           Load|Store
++// - acquire         orders  Load|Store,       (maps to lwsync)
++//                           Load|Load
++// - fence           orders Store|Store,       (maps to sync)
++//                           Load|Store,
++//                           Load|Load,
++//                          Store|Load
++//
++
++#define inlasm_sync()     __asm__ __volatile__ ("sync"   : : : "memory");
++#define inlasm_lwsync()   __asm__ __volatile__ ("lwsync" : : : "memory");
++#define inlasm_eieio()    __asm__ __volatile__ ("eieio"  : : : "memory");
++#define inlasm_isync()    __asm__ __volatile__ ("isync"  : : : "memory");
++#define inlasm_release()  inlasm_lwsync();
++#define inlasm_acquire()  inlasm_lwsync();
++// Use twi-isync for load_acquire (faster than lwsync).
++#define inlasm_acquire_reg(X) __asm__ __volatile__ ("twi 0,%0,0\n isync\n" : : "r" (X) : "memory");
++#define inlasm_fence()    inlasm_sync();
++
++inline void     OrderAccess::loadload()   { inlasm_lwsync();  }
++inline void     OrderAccess::storestore() { inlasm_lwsync();  }
++inline void     OrderAccess::loadstore()  { inlasm_lwsync();  }
++inline void     OrderAccess::storeload()  { inlasm_fence();   }
++
++inline void     OrderAccess::acquire()    { inlasm_acquire(); }
++inline void     OrderAccess::release()    { inlasm_release(); }
++inline void     OrderAccess::fence()      { inlasm_fence();   }
++
++inline jbyte    OrderAccess::load_acquire(volatile jbyte*   p) { register jbyte t = *p;   inlasm_acquire_reg(t); return t; }
++inline jshort   OrderAccess::load_acquire(volatile jshort*  p) { register jshort t = *p;  inlasm_acquire_reg(t); return t; }
++inline jint     OrderAccess::load_acquire(volatile jint*    p) { register jint t = *p;    inlasm_acquire_reg(t); return t; }
++inline jlong    OrderAccess::load_acquire(volatile jlong*   p) { register jlong t = *p;   inlasm_acquire_reg(t); return t; }
++inline jubyte   OrderAccess::load_acquire(volatile jubyte*  p) { register jubyte t = *p;  inlasm_acquire_reg(t); return t; }
++inline jushort  OrderAccess::load_acquire(volatile jushort* p) { register jushort t = *p; inlasm_acquire_reg(t); return t; }
++inline juint    OrderAccess::load_acquire(volatile juint*   p) { register juint t = *p;   inlasm_acquire_reg(t); return t; }
++inline julong   OrderAccess::load_acquire(volatile julong*  p) { return (julong)load_acquire((volatile jlong*)p); }
++inline jfloat   OrderAccess::load_acquire(volatile jfloat*  p) { register jfloat t = *p;  inlasm_acquire(); return t; }
++inline jdouble  OrderAccess::load_acquire(volatile jdouble* p) { register jdouble t = *p; inlasm_acquire(); return t; }
++
++inline intptr_t OrderAccess::load_ptr_acquire(volatile intptr_t*   p) { return (intptr_t)load_acquire((volatile jlong*)p); }
++inline void*    OrderAccess::load_ptr_acquire(volatile void*       p) { return (void*)   load_acquire((volatile jlong*)p); }
++inline void*    OrderAccess::load_ptr_acquire(const volatile void* p) { return (void*)   load_acquire((volatile jlong*)p); }
++
++inline void     OrderAccess::release_store(volatile jbyte*   p, jbyte   v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jshort*  p, jshort  v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jint*    p, jint    v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jlong*   p, jlong   v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jubyte*  p, jubyte  v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jushort* p, jushort v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile juint*   p, juint   v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile julong*  p, julong  v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jfloat*  p, jfloat  v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store(volatile jdouble* p, jdouble v) { inlasm_release(); *p = v; }
++
++inline void     OrderAccess::release_store_ptr(volatile intptr_t* p, intptr_t v) { inlasm_release(); *p = v; }
++inline void     OrderAccess::release_store_ptr(volatile void*     p, void*    v) { inlasm_release(); *(void* volatile *)p = v; }
++
++inline void     OrderAccess::store_fence(jbyte*   p, jbyte   v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jshort*  p, jshort  v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jint*    p, jint    v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jlong*   p, jlong   v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jubyte*  p, jubyte  v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jushort* p, jushort v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(juint*   p, juint   v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(julong*  p, julong  v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jfloat*  p, jfloat  v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_fence(jdouble* p, jdouble v) { *p = v; inlasm_fence(); }
++
++inline void     OrderAccess::store_ptr_fence(intptr_t* p, intptr_t v) { *p = v; inlasm_fence(); }
++inline void     OrderAccess::store_ptr_fence(void**    p, void*    v) { *p = v; inlasm_fence(); }
++
++inline void     OrderAccess::release_store_fence(volatile jbyte*   p, jbyte   v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jshort*  p, jshort  v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jint*    p, jint    v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jlong*   p, jlong   v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jubyte*  p, jubyte  v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jushort* p, jushort v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile juint*   p, juint   v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile julong*  p, julong  v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jfloat*  p, jfloat  v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_fence(volatile jdouble* p, jdouble v) { inlasm_release(); *p = v; inlasm_fence(); }
++
++inline void     OrderAccess::release_store_ptr_fence(volatile intptr_t* p, intptr_t v) { inlasm_release(); *p = v; inlasm_fence(); }
++inline void     OrderAccess::release_store_ptr_fence(volatile void*     p, void*    v) { inlasm_release(); *(void* volatile *)p = v; inlasm_fence(); }
++
++#undef inlasm_sync
++#undef inlasm_lwsync
++#undef inlasm_eieio
++#undef inlasm_isync
++#undef inlasm_release
++#undef inlasm_acquire
++#undef inlasm_fence
++
++#endif // OS_CPU_BSD_PPC_VM_ORDERACCESS_BSD_PPC_INLINE_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.cpp hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.cpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.cpp
+@@ -0,0 +1,652 @@
++/*
++ * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2015 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++// no precompiled headers
++#include "assembler_ppc.inline.hpp"
++#include "classfile/classLoader.hpp"
++#include "classfile/systemDictionary.hpp"
++#include "classfile/vmSymbols.hpp"
++#include "code/icBuffer.hpp"
++#include "code/vtableStubs.hpp"
++#include "interpreter/interpreter.hpp"
++#include "jvm_bsd.h"
++#include "memory/allocation.inline.hpp"
++#include "mutex_bsd.inline.hpp"
++#include "nativeInst_ppc.hpp"
++#include "os_share_bsd.hpp"
++#include "prims/jniFastGetField.hpp"
++#include "prims/jvm.h"
++#include "prims/jvm_misc.hpp"
++#include "runtime/arguments.hpp"
++#include "runtime/extendedPC.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/interfaceSupport.hpp"
++#include "runtime/java.hpp"
++#include "runtime/javaCalls.hpp"
++#include "runtime/mutexLocker.hpp"
++#include "runtime/osThread.hpp"
++#include "runtime/sharedRuntime.hpp"
++#include "runtime/stubRoutines.hpp"
++#include "runtime/thread.inline.hpp"
++#include "runtime/timer.hpp"
++#include "utilities/events.hpp"
++#include "utilities/vmError.hpp"
++
++// put OS-includes here
++# include <sys/types.h>
++# include <sys/mman.h>
++# include <pthread.h>
++# include <signal.h>
++# include <errno.h>
++# include <dlfcn.h>
++# include <stdlib.h>
++# include <stdio.h>
++# include <unistd.h>
++# include <sys/resource.h>
++# include <pthread.h>
++# include <sys/stat.h>
++# include <sys/time.h>
++# include <sys/utsname.h>
++# include <sys/socket.h>
++# include <sys/wait.h>
++# include <pwd.h>
++# include <poll.h>
++# include <ucontext.h>
++
++// Darwin/PowerPC exposes register state through uc_mcontext->__ss. In LP64
++// signal handlers the third argument is a ucontext64_t; mcontext_t remains the
++// 32-bit PPC context type, so using uc_mcontext decodes the wrong layout.
++#ifdef __APPLE__
++# if defined(_LP64)
++#  define PPC_CONTEXT(uc, r) (((ucontext64_t*)(uc))->uc_mcontext64->__ss.__##r)
++# elif __DARWIN_UNIX03 && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
++#  define PPC_CONTEXT(uc, r) ((uc)->uc_mcontext->__ss.__##r)
++# else
++#  define PPC_CONTEXT(uc, r) ((uc)->uc_mcontext->ss.r)
++# endif
++#endif
++
++static uintptr_t ppc_context_gpr(ucontext_t* uc, int reg) {
++  switch (reg) {
++    case 0: return PPC_CONTEXT(uc, r0);
++    case 1: return PPC_CONTEXT(uc, r1);
++    case 2: return PPC_CONTEXT(uc, r2);
++    case 3: return PPC_CONTEXT(uc, r3);
++    case 4: return PPC_CONTEXT(uc, r4);
++    case 5: return PPC_CONTEXT(uc, r5);
++    case 6: return PPC_CONTEXT(uc, r6);
++    case 7: return PPC_CONTEXT(uc, r7);
++    case 8: return PPC_CONTEXT(uc, r8);
++    case 9: return PPC_CONTEXT(uc, r9);
++    case 10: return PPC_CONTEXT(uc, r10);
++    case 11: return PPC_CONTEXT(uc, r11);
++    case 12: return PPC_CONTEXT(uc, r12);
++    case 13: return PPC_CONTEXT(uc, r13);
++    case 14: return PPC_CONTEXT(uc, r14);
++    case 15: return PPC_CONTEXT(uc, r15);
++    case 16: return PPC_CONTEXT(uc, r16);
++    case 17: return PPC_CONTEXT(uc, r17);
++    case 18: return PPC_CONTEXT(uc, r18);
++    case 19: return PPC_CONTEXT(uc, r19);
++    case 20: return PPC_CONTEXT(uc, r20);
++    case 21: return PPC_CONTEXT(uc, r21);
++    case 22: return PPC_CONTEXT(uc, r22);
++    case 23: return PPC_CONTEXT(uc, r23);
++    case 24: return PPC_CONTEXT(uc, r24);
++    case 25: return PPC_CONTEXT(uc, r25);
++    case 26: return PPC_CONTEXT(uc, r26);
++    case 27: return PPC_CONTEXT(uc, r27);
++    case 28: return PPC_CONTEXT(uc, r28);
++    case 29: return PPC_CONTEXT(uc, r29);
++    case 30: return PPC_CONTEXT(uc, r30);
++    case 31: return PPC_CONTEXT(uc, r31);
++    default: return 0;
++  }
++}
++
++address os::current_stack_pointer() {
++  intptr_t* csp;
++
++  __asm__ __volatile__ ("mr %0, r1":"=r"(csp):);
++
++  return (address) csp;
++}
++
++char* os::non_memory_address_word() {
++  // Must never look like an address returned by reserve_memory,
++  // even in its subfields (as defined by the CPU immediate fields,
++  // if the CPU splits constants across multiple instructions).
++
++  return (char*) -1;
++}
++
++void os::initialize_thread(Thread *thread) { }
++
++// Frame information (pc, sp, fp) retrieved via ucontext
++// always looks like a C-frame according to the frame
++// conventions in frame_ppc64.hpp.
++address os::Bsd::ucontext_get_pc(ucontext_t * uc) {
++  return (address)PPC_CONTEXT(uc, srr0);
++}
++
++intptr_t* os::Bsd::ucontext_get_sp(ucontext_t * uc) {
++  return (intptr_t*)PPC_CONTEXT(uc, r1);
++}
++
++intptr_t* os::Bsd::ucontext_get_fp(ucontext_t * uc) {
++  return NULL;
++}
++
++ExtendedPC os::fetch_frame_from_context(void* ucVoid,
++                    intptr_t** ret_sp, intptr_t** ret_fp) {
++
++  ExtendedPC  epc;
++  ucontext_t* uc = (ucontext_t*)ucVoid;
++
++  if (uc != NULL) {
++    epc = ExtendedPC(os::Bsd::ucontext_get_pc(uc));
++    if (ret_sp) *ret_sp = os::Bsd::ucontext_get_sp(uc);
++    if (ret_fp) *ret_fp = os::Bsd::ucontext_get_fp(uc);
++  } else {
++    // construct empty ExtendedPC for return value checking
++    epc = ExtendedPC(NULL);
++    if (ret_sp) *ret_sp = (intptr_t *)NULL;
++    if (ret_fp) *ret_fp = (intptr_t *)NULL;
++  }
++
++  return epc;
++}
++
++frame os::fetch_frame_from_context(void* ucVoid) {
++  intptr_t* sp;
++  intptr_t* fp;
++  ExtendedPC epc = fetch_frame_from_context(ucVoid, &sp, &fp);
++  return frame(sp, epc.pc());
++}
++
++frame os::get_sender_for_C_frame(frame* fr) {
++  if (*fr->sp() == 0) {
++    // fr is the last C frame
++    return frame(NULL, NULL);
++  }
++  return frame(fr->sender_sp(), fr->sender_pc());
++}
++
++
++frame os::current_frame() {
++  intptr_t* csp = (intptr_t*) *((intptr_t*) os::current_stack_pointer());
++  // hack.
++  frame topframe(csp, (address)0x8);
++  // return sender of current topframe which hopefully has pc != NULL.
++  return os::get_sender_for_C_frame(&topframe);
++}
++
++// Utility functions
++
++extern "C" JNIEXPORT int
++JVM_handle_bsd_signal(int sig,
++                        siginfo_t* info,
++                        void* ucVoid,
++                        int abort_if_unrecognized) {
++  ucontext_t* uc = (ucontext_t*) ucVoid;
++
++  Thread* t = ThreadLocalStorage::get_thread_slow();
++
++  // Must do this before SignalHandlerMark, if crash protection installed we will longjmp away
++  // (no destructors can be run)
++  os::ThreadCrashProtection::check_crash_protection(sig, t);
++
++  SignalHandlerMark shm(t);
++
++  // Note: it's not uncommon that JNI code uses signal/sigset to install
++  // then restore certain signal handler (e.g. to temporarily block SIGPIPE,
++  // or have a SIGILL handler when detecting CPU type). When that happens,
++  // JVM_handle_bsd_signal() might be invoked with junk info/ucVoid. To
++  // avoid unnecessary crash when libjsig is not preloaded, try handle signals
++  // that do not require siginfo/ucontext first.
++
++  if (sig == SIGPIPE || sig == SIGXFSZ) {
++    if (os::Bsd::chained_handler(sig, info, ucVoid)) {
++      return true;
++    } else {
++      if (PrintMiscellaneous && (WizardMode || Verbose)) {
++        warning("Ignoring SIGPIPE - see bug 4229104");
++      }
++      return true;
++    }
++  }
++
++  JavaThread* thread = NULL;
++  VMThread* vmthread = NULL;
++  if (os::Bsd::signal_handlers_are_installed) {
++    if (t != NULL) {
++      if(t->is_Java_thread()) {
++        thread = (JavaThread*)t;
++      } else if(t->is_VM_thread()) {
++        vmthread = (VMThread *)t;
++      }
++    }
++  }
++
++  // Moved SafeFetch32 handling outside thread!=NULL conditional block to make
++  // it work if no associated JavaThread object exists.
++  if ((sig == SIGSEGV || sig == SIGBUS) && uc) {
++    address const pc = os::Bsd::ucontext_get_pc(uc);
++    if (pc && StubRoutines::is_safefetch_fault(pc)) {
++      PPC_CONTEXT(uc, srr0) = (uintptr_t)StubRoutines::continuation_for_safefetch_fault(pc);
++      return true;
++    }
++  }
++
++  // decide if this trap can be handled by a stub
++  address stub = NULL;
++  address pc   = NULL;
++
++  //%note os_trap_1
++  if (info != NULL && uc != NULL && thread != NULL) {
++    pc = (address) os::Bsd::ucontext_get_pc(uc);
++
++    // Handle ALL stack overflow variations here
++    if (sig == SIGSEGV) {
++      // Darwin/BSD reports the faulting address for stack overflow and null
++      // checks. The PPC stack-bang decoder is Linux-only.
++      address addr = info == NULL ? NULL : (address)info->si_addr;
++
++      // Check if fault address is within thread stack.
++      if (addr != NULL &&
++          addr < thread->stack_base() &&
++          addr >= thread->stack_base() - thread->stack_size()) {
++        // stack overflow
++        if (thread->in_stack_yellow_zone(addr)) {
++          thread->disable_stack_yellow_zone();
++          if (thread->thread_state() == _thread_in_Java) {
++            // Throw a stack overflow exception.
++            // Guard pages will be reenabled while unwinding the stack.
++            stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::STACK_OVERFLOW);
++          } else {
++            // Thread was in the vm or native code. Return and try to finish.
++            return 1;
++          }
++        } else if (thread->in_stack_red_zone(addr)) {
++          // Fatal red zone violation.  Disable the guard pages and fall through
++          // to handle_unexpected_exception way down below.
++          thread->disable_stack_red_zone();
++          tty->print_raw_cr("An irrecoverable stack overflow has occurred.");
++
++          // This is a likely cause, but hard to verify. Let's just print
++          // it as a hint.
++          tty->print_raw_cr("Please check if any of your loaded .so files has "
++                            "enabled executable stack (see man page execstack(8))");
++        } else {
++          // Accessing stack address below sp may cause SEGV if current
++          // thread has MAP_GROWSDOWN stack. This should only happen when
++          // current thread was created by user code with MAP_GROWSDOWN flag
++          // and then attached to VM. See notes in os_bsd.cpp.
++          if (thread->osthread()->expanding_stack() == 0) {
++             thread->osthread()->set_expanding_stack();
++             // Darwin/BSD does not use Linux MAP_GROWSDOWN stack expansion.
++             thread->osthread()->clear_expanding_stack();
++          } else {
++             fatal("recursive segv. expanding stack.");
++          }
++        }
++      }
++    }
++
++    if (thread->thread_state() == _thread_in_Java) {
++      // Java thread running in Java code => find exception handler if any
++      // a fault inside compiled code, the interpreter, or a stub
++
++      // A VM-related SIGILL may only occur if we are not in the zero page.
++      // On AIX, we get a SIGILL if we jump to 0x0 or to somewhere else
++      // in the zero page, because it is filled with 0x0. We ignore
++      // explicit SIGILLs in the zero page.
++      if (sig == SIGILL && (pc < (address) 0x200)) {
++        if (TraceTraps) {
++          tty->print_raw_cr("SIGILL happened inside zero page.");
++        }
++        goto report_and_die;
++      }
++
++      CodeBlob *cb = NULL;
++      // Handle signal from NativeJump::patch_verified_entry().
++      if (CodeCache::contains((void*)pc) &&
++          (( TrapBasedNotEntrantChecks && sig == SIGTRAP && nativeInstruction_at(pc)->is_sigtrap_zombie_not_entrant()) ||
++           (!TrapBasedNotEntrantChecks && sig == SIGILL  && nativeInstruction_at(pc)->is_sigill_zombie_not_entrant()))) {
++        if (TraceTraps) {
++          tty->print_cr("trap: zombie_not_entrant (%s)", (sig == SIGTRAP) ? "SIGTRAP" : "SIGILL");
++        }
++        stub = SharedRuntime::get_handle_wrong_method_stub();
++      }
++
++      else if ((sig == SIGSEGV || sig == SIGBUS) &&
++               // A bsd-ppc64 kernel before 2.6.6 doesn't set si_addr on some segfaults
++               // in 64bit mode (cf. http://www.kernel.org/pub/bsd/kernel/v2.6/ChangeLog-2.6.6),
++               // especially when we try to read from the safepoint polling page. So the check
++               //   (address)info->si_addr == os::get_standard_polling_page()
++               // doesn't work for us. We use:
++               CodeCache::contains((void*) pc) &&
++               ((NativeInstruction*)pc)->is_safepoint_poll() &&
++               ((cb = CodeCache::find_blob(pc)) != NULL) &&
++               cb->is_nmethod()) {
++        if (TraceTraps) {
++          tty->print_cr("trap: safepoint_poll at " INTPTR_FORMAT " (SIGSEGV)", p2i(pc));
++        }
++        stub = SharedRuntime::get_poll_stub(pc);
++      }
++
++      // SIGTRAP-based ic miss check in compiled code.
++      else if (sig == SIGTRAP && TrapBasedICMissChecks &&
++               CodeCache::contains((void*)pc) &&
++               nativeInstruction_at(pc)->is_sigtrap_ic_miss_check()) {
++        if (TraceTraps) {
++          tty->print_cr("trap: ic_miss_check at " INTPTR_FORMAT " (SIGTRAP)", p2i(pc));
++        }
++        stub = SharedRuntime::get_ic_miss_stub();
++      }
++
++      // SIGTRAP-based implicit null check in compiled code.
++      else if (sig == SIGTRAP && TrapBasedNullChecks &&
++               CodeCache::contains((void*)pc) &&
++               nativeInstruction_at(pc)->is_sigtrap_null_check()) {
++        if (TraceTraps) {
++          tty->print_cr("trap: null_check at " INTPTR_FORMAT " (SIGTRAP)", p2i(pc));
++        }
++        stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
++      }
++
++      // SIGSEGV-based implicit null check in compiled code.
++      else if (sig == SIGSEGV && ImplicitNullChecks &&
++               CodeCache::contains((void*) pc) &&
++               !MacroAssembler::needs_explicit_null_check((intptr_t) info->si_addr)) {
++        if (TraceTraps) {
++          tty->print_cr("trap: null_check at " INTPTR_FORMAT " (SIGSEGV)", p2i(pc));
++        }
++        stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
++      }
++
++#ifdef COMPILER2
++      // SIGTRAP-based implicit range check in compiled code.
++      else if (sig == SIGTRAP && TrapBasedRangeChecks &&
++               CodeCache::contains((void*)pc) &&
++               nativeInstruction_at(pc)->is_sigtrap_range_check()) {
++        if (TraceTraps) {
++          tty->print_cr("trap: range_check at " INTPTR_FORMAT " (SIGTRAP)", p2i(pc));
++        }
++        stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
++      }
++#endif
++      else if (sig == SIGBUS) {
++        // BugId 4454115: A read from a MappedByteBuffer can fault here if the
++        // underlying file has been truncated. Do not crash the VM in such a case.
++        CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
++        nmethod* nm = (cb != NULL && cb->is_nmethod()) ? (nmethod*)cb : NULL;
++        if (nm != NULL && nm->has_unsafe_access()) {
++          // We don't really need a stub here! Just set the pending exeption and
++          // continue at the next instruction after the faulting read. Returning
++          // garbage from this read is ok.
++          thread->set_pending_unsafe_access_error();
++          PPC_CONTEXT(uc, srr0) = ((uintptr_t)pc) + 4;
++          return true;
++        }
++      }
++    }
++
++    else { // thread->thread_state() != _thread_in_Java
++      if (sig == SIGILL && VM_Version::is_determine_features_test_running()) {
++        // SIGILL must be caused by VM_Version::determine_features().
++        *(int *)pc = 0; // patch instruction to 0 to indicate that it causes a SIGILL,
++                        // flushing of icache is not necessary.
++        stub = pc + 4;  // continue with next instruction.
++      }
++      else if (thread->thread_state() == _thread_in_vm &&
++               sig == SIGBUS && thread->doing_unsafe_access()) {
++        // We don't really need a stub here! Just set the pending exeption and
++        // continue at the next instruction after the faulting read. Returning
++        // garbage from this read is ok.
++        thread->set_pending_unsafe_access_error();
++        PPC_CONTEXT(uc, srr0) = ((uintptr_t)pc) + 4;
++        return true;
++      }
++    }
++
++    // Check to see if we caught a write to the memory serialization page.
++    // Darwin/BSD reports the faulting address, so use si_addr directly
++    // instead of the Linux-only PPC instruction decoder below.
++    if (stub == NULL &&
++        (sig == SIGSEGV || sig == SIGBUS) &&
++        info != NULL &&
++        os::is_memory_serialize_page(thread, (address)info->si_addr)) {
++      os::block_on_serialize_page_trap();
++      return true;
++    }
++
++    // Check to see if we caught the safepoint code in the
++    // process of write protecting the memory serialization page.
++    // It write enables the page immediately after protecting it
++    // so we can just return to retry the write.
++    //
++    // The PPC instruction decoder used here is implemented only for Linux
++    // ucontext layouts. On BSD/Darwin, safepoint polling is handled above and
++    // this fallback must not call into the Linux-only decoder.
++#if defined(LINUX)
++    if (stub == NULL &&
++        (sig == SIGSEGV) &&
++        // Si_addr may not be valid due to a bug in the bsd-ppc64 kernel (see comment above).
++        // Use is_memory_serialization instead of si_addr.
++        pc != NULL && pc >= (address)os::vm_page_size() &&
++        ((NativeInstruction*)pc)->is_memory_serialization(thread, ucVoid)) {
++      // Synchronization problem in the pseudo memory barrier code (bug id 6546278)
++      // Block current thread until the memory serialize page permission restored.
++      os::block_on_serialize_page_trap();
++      return true;
++    }
++#endif
++  }
++
++  if (stub != NULL) {
++    // Save all thread context in case we need to restore it.
++    if (thread != NULL) thread->set_saved_exception_pc(pc);
++    PPC_CONTEXT(uc, srr0) = (uintptr_t)stub;
++    return true;
++  }
++
++  // signal-chaining
++  if (os::Bsd::chained_handler(sig, info, ucVoid)) {
++    return true;
++  }
++
++  if (!abort_if_unrecognized) {
++    // caller wants another chance, so give it to him
++    return false;
++  }
++
++  if (pc == NULL && uc != NULL) {
++    pc = os::Bsd::ucontext_get_pc(uc);
++  }
++
++report_and_die:
++  // unmask current signal
++  sigset_t newset;
++  sigemptyset(&newset);
++  sigaddset(&newset, sig);
++  sigprocmask(SIG_UNBLOCK, &newset, NULL);
++
++  VMError err(t, sig, pc, info, ucVoid);
++  err.report_and_die();
++
++  ShouldNotReachHere();
++  return false;
++}
++
++void os::Bsd::init_thread_fpu_state(void) {
++  // Nothing to initialize for the Darwin/PPC64 FPU state here.
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// thread stack
++
++size_t os::Bsd::min_stack_allowed = 128*K;
++
++bool os::Bsd::supports_variable_stack_size() { return true; }
++
++// return default stack size for thr_type
++size_t os::Bsd::default_stack_size(os::ThreadType thr_type) {
++  // default stack size (compiler thread needs larger stack)
++  // Notice that the setting for compiler threads here have no impact
++  // because of the strange 'fallback logic' in os::create_thread().
++  // Better set CompilerThreadStackSize in globals_<os_cpu>.hpp if you want to
++  // specify a different stack size for compiler threads!
++  size_t s = (thr_type == os::compiler_thread ? 4 * M : 1024 * K);
++  return s;
++}
++
++size_t os::Bsd::default_guard_size(os::ThreadType thr_type) {
++  return 2 * page_size();
++}
++
++// Java thread:
++//
++//   Low memory addresses
++//    +------------------------+
++//    |                        |\  JavaThread created by VM does not have glibc
++//    |    glibc guard page    | - guard, attached Java thread usually has
++//    |                        |/  1 page glibc guard.
++// P1 +------------------------+ Thread::stack_base() - Thread::stack_size()
++//    |                        |\
++//    |  HotSpot Guard Pages   | - red and yellow pages
++//    |                        |/
++//    +------------------------+ JavaThread::stack_yellow_zone_base()
++//    |                        |\
++//    |      Normal Stack      | -
++//    |                        |/
++// P2 +------------------------+ Thread::stack_base()
++//
++// Non-Java thread:
++//
++//   Low memory addresses
++//    +------------------------+
++//    |                        |\
++//    |  glibc guard page      | - usually 1 page
++//    |                        |/
++// P1 +------------------------+ Thread::stack_base() - Thread::stack_size()
++//    |                        |\
++//    |      Normal Stack      | -
++//    |                        |/
++// P2 +------------------------+ Thread::stack_base()
++//
++// ** P1 (aka bottom) and size ( P2 = P1 - size) are the address and stack size returned from
++//    pthread_attr_getstack()
++
++static void current_stack_region(address * bottom, size_t * size) {
++  pthread_t self = pthread_self();
++  void *stacktop = pthread_get_stackaddr_np(self);
++  *size = pthread_get_stacksize_np(self);
++  *bottom = (address)stacktop - *size;
++
++  assert(os::current_stack_pointer() >= *bottom &&
++         os::current_stack_pointer() < *bottom + *size, "just checking");
++}
++
++address os::current_stack_base() {
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return (bottom + size);
++}
++
++size_t os::current_stack_size() {
++  // stack size includes normal stack and HotSpot guard pages
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return size;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++// helper functions for fatal error handler
++
++void os::print_context(outputStream *st, void *context) {
++  if (context == NULL) return;
++
++  ucontext_t* uc = (ucontext_t*)context;
++
++  st->print_cr("Registers:");
++  st->print("pc =" INTPTR_FORMAT "  ", PPC_CONTEXT(uc, srr0));
++  st->print("lr =" INTPTR_FORMAT "  ", PPC_CONTEXT(uc, lr));
++  st->print("ctr=" INTPTR_FORMAT "  ", PPC_CONTEXT(uc, ctr));
++  st->cr();
++  for (int i = 0; i < 32; i++) {
++    st->print("r%-2d=" INTPTR_FORMAT "  ", i, ppc_context_gpr(uc, i));
++    if (i % 3 == 2) st->cr();
++  }
++  st->cr();
++  st->cr();
++
++  intptr_t *sp = (intptr_t *)os::Bsd::ucontext_get_sp(uc);
++  st->print_cr("Top of Stack: (sp=" PTR_FORMAT ")", p2i(sp));
++  print_hex_dump(st, (address)sp, (address)(sp + 128), sizeof(intptr_t));
++  st->cr();
++
++  // Note: it may be unsafe to inspect memory near pc. For example, pc may
++  // point to garbage if entry point in an nmethod is corrupted. Leave
++  // this at the end, and hope for the best.
++  address pc = os::Bsd::ucontext_get_pc(uc);
++  st->print_cr("Instructions: (pc=" PTR_FORMAT ")", p2i(pc));
++  if (pc != NULL && pc >= (address)64) {
++    print_hex_dump(st, pc - 64, pc + 64, /*instrsize=*/4);
++  } else {
++    st->print_cr("pc is not safe to inspect");
++  }
++  st->cr();
++}
++
++void os::print_register_info(outputStream *st, void *context) {
++  if (context == NULL) return;
++
++  ucontext_t *uc = (ucontext_t*)context;
++
++  st->print_cr("Register to memory mapping:");
++  st->cr();
++
++  // this is only for the "general purpose" registers
++  for (int i = 0; i < 32; i++) {
++    st->print("r%-2d=", i);
++    print_location(st, ppc_context_gpr(uc, i));
++  }
++  st->cr();
++}
++
++extern "C" {
++  int SpinPause() {
++    return 0;
++  }
++}
++
++#ifndef PRODUCT
++void os::verify_stack_alignment() {
++  assert(((intptr_t)os::current_stack_pointer() & (StackAlignmentInBytes-1)) == 0, "incorrect stack alignment");
++}
++#endif
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.hpp hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/os_bsd_ppc.hpp
+@@ -0,0 +1,35 @@
++/*
++ * Copyright (c) 2002, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_OS_BSD_PPC_HPP
++#define OS_CPU_BSD_PPC_VM_OS_BSD_PPC_HPP
++
++  static void setup_fpu() {}
++
++  // Used to register dynamic code cache area with the OS
++  // Note: Currently only used in 64 bit Windows implementations
++  static bool register_code_area(char *low, char *high) { return true; }
++
++#endif // OS_CPU_BSD_PPC_VM_OS_BSD_PPC_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/prefetch_bsd_ppc.inline.hpp hotspot/src/os_cpu/bsd_ppc/vm/prefetch_bsd_ppc.inline.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/prefetch_bsd_ppc.inline.hpp
+@@ -0,0 +1,50 @@
++/*
++ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_PREFETCH_BSD_PPC_INLINE_HPP
++#define OS_CPU_BSD_PPC_VM_PREFETCH_BSD_PPC_INLINE_HPP
++
++#include "runtime/prefetch.hpp"
++
++
++inline void Prefetch::read(void *loc, intx interval) {
++  __asm__ __volatile__ (
++    "   dcbt   0, %0       \n"
++    :
++    : /*%0*/"r" ( ((address)loc) +((long)interval) )
++    //:
++    );
++}
++
++inline void Prefetch::write(void *loc, intx interval) {
++  __asm__ __volatile__ (
++    "   dcbtst 0, %0       \n"
++    :
++    : /*%0*/"r" ( ((address)loc) +((long)interval) )
++    //:
++    );
++}
++
++#endif // OS_CPU_BSD_PPC_VM_PREFETCH_BSD_PPC_INLINE_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.cpp hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.cpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.cpp
+@@ -0,0 +1,98 @@
++/*
++ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2014 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/os.hpp"
++#include "runtime/thread.hpp"
++
++#include <ucontext.h>
++
++#ifdef __APPLE__
++# if __DARWIN_UNIX03 && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
++#  define PPC_CONTEXT(uc, r) ((uc)->uc_mcontext->__ss.__##r)
++# else
++#  define PPC_CONTEXT(uc, r) ((uc)->uc_mcontext->ss.r)
++# endif
++#endif
++
++bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
++  assert(this->is_Java_thread(), "must be JavaThread");
++
++  // If we have a last_Java_frame, then we should use it even if
++  // isInJava == true.  It should be more reliable than ucontext info.
++  if (has_last_Java_frame() && frame_anchor()->walkable()) {
++    *fr_addr = pd_last_frame();
++    return true;
++  }
++
++  // At this point, we don't have a last_Java_frame, so
++  // we try to glean some information out of the ucontext
++  // if we were running Java code when SIGPROF came in.
++  if (isInJava) {
++    ucontext_t* uc = (ucontext_t*) ucontext;
++    frame ret_frame(os::Bsd::ucontext_get_sp(uc), os::Bsd::ucontext_get_pc(uc));
++
++    if (ret_frame.pc() == NULL) {
++      // ucontext wasn't useful
++      return false;
++    }
++
++    if (ret_frame.is_interpreted_frame()) {
++      frame::ijava_state *istate = ret_frame.get_ijava_state();
++      const Method *m = (const Method*)(istate->method);
++      if (m == NULL || !m->is_valid_method()) return false;
++      if (!Metaspace::contains((const void*)m)) return false;
++
++      uint64_t reg_bcp = PPC_CONTEXT(uc, r14);
++      uint64_t istate_bcp = istate->bcp;
++      uint64_t code_start = (uint64_t)(m->code_base());
++      uint64_t code_end = (uint64_t)(m->code_base() + m->code_size());
++      if (istate_bcp >= code_start && istate_bcp < code_end) {
++        // we have a valid bcp, don't touch it, do nothing
++      } else if (reg_bcp >= code_start && reg_bcp < code_end) {
++        istate->bcp = reg_bcp;
++      } else {
++        return false;
++      }
++    }
++    if (!ret_frame.safe_for_sender(this)) {
++      // nothing else to try if the frame isn't good
++      return false;
++    }
++    *fr_addr = ret_frame;
++    return true;
++  }
++  // nothing else to try
++  return false;
++}
++
++// Forte Analyzer AsyncGetCallTrace profiling support is not implemented on Bsd/PPC.
++bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava) {
++  assert(this->is_Java_thread(), "must be JavaThread");
++  return pd_get_top_frame_for_profiling(fr_addr, ucontext, isInJava);
++}
++
++void JavaThread::cache_global_variables() { }
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.hpp hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/thread_bsd_ppc.hpp
+@@ -0,0 +1,85 @@
++/*
++ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_THREAD_BSD_PPC_HPP
++#define OS_CPU_BSD_PPC_VM_THREAD_BSD_PPC_HPP
++
++ private:
++
++  void pd_initialize() {
++    _anchor.clear();
++    _last_interpreter_fp = NULL;
++  }
++
++  // The `last' frame is the youngest Java frame on the thread's stack.
++  frame pd_last_frame() {
++    assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
++
++    intptr_t* sp = last_Java_sp();
++    address pc = _anchor.last_Java_pc();
++
++    // Last_Java_pc ist not set, if we come here from compiled code.
++    if (pc == NULL) {
++      pc = (address) *(sp + 2);
++    }
++
++    return frame(sp, pc);
++  }
++
++ public:
++
++  void set_base_of_stack_pointer(intptr_t* base_sp) {}
++  intptr_t* base_of_stack_pointer() { return NULL; }
++  void record_base_of_stack_pointer() {}
++
++  // These routines are only used on cpu architectures that
++  // have separate register stacks (Itanium).
++  static bool register_stack_overflow() { return false; }
++  static void enable_register_stack_guard() {}
++  static void disable_register_stack_guard() {}
++
++  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext, bool isInJava);
++
++  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
++
++ protected:
++
++  // -Xprof support
++  //
++  // In order to find the last Java fp from an async profile
++  // tick, we store the current interpreter fp in the thread.
++  // This value is only valid while we are in the C++ interpreter
++  // and profiling.
++  intptr_t *_last_interpreter_fp;
++
++ public:
++
++  static ByteSize last_interpreter_fp_offset() {
++    return byte_offset_of(JavaThread, _last_interpreter_fp);
++  }
++
++  intptr_t* last_interpreter_fp() { return _last_interpreter_fp; }
++
++#endif // OS_CPU_BSD_PPC_VM_THREAD_BSD_PPC_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.cpp hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.cpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.cpp
+@@ -0,0 +1,39 @@
++/*
++ * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/threadLocalStorage.hpp"
++
++void ThreadLocalStorage::generate_code_for_get_thread() {
++    // nothing we can do here for user-level thread
++}
++
++void ThreadLocalStorage::pd_init() {
++  // Nothing to do
++}
++
++void ThreadLocalStorage::pd_set_thread(Thread* thread) {
++  os::thread_local_storage_at_put(ThreadLocalStorage::thread_index(), thread);
++}
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.hpp hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/threadLS_bsd_ppc.hpp
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_THREADLS_BSD_PPC_HPP
++#define OS_CPU_BSD_PPC_VM_THREADLS_BSD_PPC_HPP
++
++  // Processor dependent parts of ThreadLocalStorage
++
++public:
++  static Thread* thread() {
++    return (Thread *) os::thread_local_storage_at(thread_index());
++  }
++
++#endif // OS_CPU_BSD_PPC_VM_THREADLS_BSD_PPC_HPP
+
+diff --git hotspot/src/os_cpu/bsd_ppc/vm/vmStructs_bsd_ppc.hpp hotspot/src/os_cpu/bsd_ppc/vm/vmStructs_bsd_ppc.hpp
+new file mode 100644
+--- /dev/null
++++ hotspot/src/os_cpu/bsd_ppc/vm/vmStructs_bsd_ppc.hpp
+@@ -0,0 +1,56 @@
++/*
++ * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2012, 2013 SAP AG. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_BSD_PPC_VM_VMSTRUCTS_BSD_PPC_HPP
++#define OS_CPU_BSD_PPC_VM_VMSTRUCTS_BSD_PPC_HPP
++
++// These are the OS and CPU-specific fields, types and integer
++// constants required by the Serviceability Agent. This file is
++// referenced by vmStructs.cpp.
++
++#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
++                                                                                                                                     \
++  /******************************/                                                                                                   \
++  /* Threads (NOTE: incomplete) */                                                                                                   \
++  /******************************/                                                                                                   \
++  nonstatic_field(OSThread,                      _thread_id,                                      OSThread::thread_id_t)             \
++  nonstatic_field(OSThread,                      _pthread_id,                                     pthread_t)
++
++
++#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type) \
++                                                                          \
++  /**********************/                                                \
++  /* Posix Thread IDs   */                                                \
++  /**********************/                                                \
++                                                                          \
++  declare_integer_type(OSThread::thread_id_t)                             \
++  declare_integer_type(pid_t)                                             \
++  declare_unsigned_integer_type(pthread_t)
++
++#define VM_INT_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#define VM_LONG_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#endif // OS_CPU_BSD_PPC_VM_VMSTRUCTS_BSD_PPC_HPP


### PR DESCRIPTION
Add tested Darwin/PPC64 server VM support for OpenJDK 8, enabling the JIT by default on ppc64 while keeping ppc on Zero. Includes HotSpot runtime fixes validated against interpreter, mixed JIT, and forced JIT benchmark runs.

Validated with DaCapo 9.12 small suite: luindex, lusearch, pmd, and xalan all pass under -Xint, mixed JIT, and -Xbatch on PPC64 Darwin. Mixed JIT showed roughly 1.7x to 23x speedup over interpreter depending on workload.

Primary motivation for this patch was to improve performance on my RuneScape private server. 
