### PR TITLE
gcc16: Fix Tiger build

### DIFF
--- a/lang/gcc16/Portfile
+++ b/lang/gcc16/Portfile
@@ -262,14 +262,14 @@ platform darwin 8 {
                 port:flex \
                 port:gmake
 
-    # gmake dependency may be able to be dropped next release, problem fixed in commit b081225
+    # gmake dependency may be able to be dropped next release, problem fixed in https://github.com/gcc-mirror/gcc/commit/b081225
     build.cmd ${prefix}/bin/gmake
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117834
     patchfiles-append   darwin8-define-PTHREAD_RWLOCK_INITIALIZER.patch
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117857
     patchfiles-append   darwin8-ttyname_r.patch
-    # issue fixed in commit 83f0ad4, was also added later in a commit for gcc16, can be dropped next release
+    # issue fixed https://github.com/gcc-mirror/gcc/commit/83f0ad40a472d98bf1ed38b7d1c4865fdcb5e068 can be dropped next release
     patchfiles-append   darwin8-iconv.patch
     # workaround for Tiger not having _SC_NPROCESSORS_ONLN
     # adapted from https://trac.macports.org/ticket/45832

--- a/lang/gcc16/Portfile
+++ b/lang/gcc16/Portfile
@@ -259,12 +259,23 @@ platform darwin {
 # Keep Tiger stuff isolated
 platform darwin 8 {
     depends_build-append \
-                port:flex
+                port:flex \
+                port:gmake
+
+    # gmake dependency may be able to be dropped next release, problem fixed in commit b081225
+    build.cmd ${prefix}/bin/gmake
 
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117834
     patchfiles-append   darwin8-define-PTHREAD_RWLOCK_INITIALIZER.patch
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117857
     patchfiles-append   darwin8-ttyname_r.patch
+    # issue fixed in commit 83f0ad4, was also added later in a commit for gcc16, can be dropped next release
+    patchfiles-append   darwin8-iconv.patch
+    # workaround for Tiger not having _SC_NPROCESSORS_ONLN
+    # adapted from https://trac.macports.org/ticket/45832
+    patchfiles-append   darwin8-core-count.patch
+    # surpress some incompatible-pointer-type errors where needed
+    patchfiles-append   darwin8-pointer-types.patch
 }
 
 configure.env-append \

--- a/lang/gcc16/files/darwin8-core-count.patch
+++ b/lang/gcc16/files/darwin8-core-count.patch
@@ -18,7 +18,7 @@
      num_images_char = getenv ("NUMBER_OF_PROCESSORS");
  #elif defined (__hpux__)
      return mpctl (MPC_GETNUMSPUS, 0, 0);
-+#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
++#elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050)
 +{
 +    int nm[2];
 +    size_t len = 4;

--- a/lang/gcc16/files/darwin8-core-count.patch
+++ b/lang/gcc16/files/darwin8-core-count.patch
@@ -5,7 +5,7 @@
  #include <string.h>
  #include <unistd.h>
 +#ifdef __APPLE__
-+#include "AvailabilityMacros.h"
++#include <AvailabilityMacros.h>
 +#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
 +#include <sys/param.h>
 +#include <sys/sysctl.h>

--- a/lang/gcc16/files/darwin8-core-count.patch
+++ b/lang/gcc16/files/darwin8-core-count.patch
@@ -5,7 +5,7 @@
  #include <string.h>
  #include <unistd.h>
 +#include "AvailabilityMacros.h"
-+#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
 +#include <sys/param.h>
 +#include <sys/sysctl.h>
 +#endif
@@ -16,7 +16,7 @@
      num_images_char = getenv ("NUMBER_OF_PROCESSORS");
  #elif defined (__hpux__)
      return mpctl (MPC_GETNUMSPUS, 0, 0);
-+#elif __MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
++#elif MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
 +{
 +    int nm[2];
 +    size_t len = 4;

--- a/lang/gcc16/files/darwin8-core-count.patch
+++ b/lang/gcc16/files/darwin8-core-count.patch
@@ -1,18 +1,20 @@
 --- libgfortran/caf/shmem/supervisor.c
 +++ libgfortran/caf/shmem/supervisor.c
-@@ -31,6 +31,11 @@
+@@ -31,6 +31,13 @@
  #include <signal.h>
  #include <string.h>
  #include <unistd.h>
++#ifdef __APPLE__
 +#include "AvailabilityMacros.h"
 +#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
 +#include <sys/param.h>
 +#include <sys/sysctl.h>
 +#endif
++#endif
  #ifdef HAVE_WAIT_H
  #include <wait.h>
  #elif HAVE_SYS_WAIT_H
-@@ -74,6 +79,22 @@
+@@ -74,6 +81,22 @@
      num_images_char = getenv ("NUMBER_OF_PROCESSORS");
  #elif defined (__hpux__)
      return mpctl (MPC_GETNUMSPUS, 0, 0);

--- a/lang/gcc16/files/darwin8-core-count.patch
+++ b/lang/gcc16/files/darwin8-core-count.patch
@@ -1,0 +1,37 @@
+--- libgfortran/caf/shmem/supervisor.c
++++ libgfortran/caf/shmem/supervisor.c
+@@ -31,6 +31,11 @@
+ #include <signal.h>
+ #include <string.h>
+ #include <unistd.h>
++#include "AvailabilityMacros.h"
++#if __MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
++#include <sys/param.h>
++#include <sys/sysctl.h>
++#endif
+ #ifdef HAVE_WAIT_H
+ #include <wait.h>
+ #elif HAVE_SYS_WAIT_H
+@@ -74,6 +79,22 @@
+     num_images_char = getenv ("NUMBER_OF_PROCESSORS");
+ #elif defined (__hpux__)
+     return mpctl (MPC_GETNUMSPUS, 0, 0);
++#elif __MAC_OS_X_VERSION_MIN_REQUIRED < 1050 || ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1050
++{
++    int nm[2];
++    size_t len = 4;
++    uint32_t count;
++ 
++    nm[0] = CTL_HW; nm[1] = HW_AVAILCPU;
++    sysctl(nm, 2, &count, &len, NULL, 0);
++ 
++    if(count < 1) {
++    nm[1] = HW_NCPU;
++    sysctl(nm, 2, &count, &len, NULL, 0);
++    if(count < 1) { count = 1; }
++    }
++    return count;
++}
+ #else
+ #error "Unsupported system: No known way to get number of cores!"
+ #endif

--- a/lang/gcc16/files/darwin8-iconv.patch
+++ b/lang/gcc16/files/darwin8-iconv.patch
@@ -1,0 +1,35 @@
+--- libstdc++-v3/src/c++20/format.cc
++++ libstdc++-v3/src/c++20/format.cc
+@@ -58,6 +58,15 @@ struct mutex
+ };
+ #endif
+ 
++#ifdef _GLIBCXX_HAVE_ICONV
++// Detect whether type T* can be used as the second argument to iconv.
++// SUSv2 used 'const char**', but glibc 2.2 and POSIX.1-2003 uses 'char**'.
++template<typename T>
++  concept iconv_input = requires (::iconv_t cd, T in, size_t n, char** out) {
++    ::iconv(cd, &in, &n, out, &n);
++  };
++#endif
++
+ // A non-standard locale::facet that caches the locale's std::text_encoding
+ // and an iconv descriptor for converting from that encoding to UTF-8.
+ struct __encoding : locale::facet
+@@ -111,12 +120,13 @@
+     bool done = false;
+ 
+     auto overwrite = [&](char* p, size_t n) {
++      using input_t = __conditional_t<iconv_input<char*>, char*, const char*>;
+       auto inbytes
+-	= const_cast<char*>(input.data()) + input.size() - inbytesleft;
++       = const_cast<input_t>(input.data()) + input.size() - inbytesleft;
+       char* outbytes = p + written;
+       size_t outbytesleft = n - written;
+-      size_t res = ::iconv(_M_cd, &inbytes, &inbytesleft,
+-			   &outbytes, &outbytesleft);
++      size_t res = ::iconv(_M_cd, &inbytes, &inbytesleft, &outbytes,
++                          &outbytesleft);
+       if (res == (size_t)-1)
+ 	{
+ 	  if (errno != E2BIG)

--- a/lang/gcc16/files/darwin8-pointer-types.patch
+++ b/lang/gcc16/files/darwin8-pointer-types.patch
@@ -1,0 +1,33 @@
+--- libgm2/libm2log/Makefile.in
++++ libgm2/libm2log/Makefile.in
+@@ -409,7 +409,7 @@
+ 	"CC_FOR_BUILD=$(CC_FOR_BUILD)" \
+ 	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
+ 	"GM2_FOR_TARGET=$(GM2_FOR_TARGET)" \
+-	"CFLAGS=$(CFLAGS)" \
++	"CFLAGS=$(CFLAGS) -Wno-error=incompatible-pointer-types" \
+ 	"CXXFLAGS=$(CXXFLAGS)" \
+ 	"CFLAGS_FOR_BUILD=$(CFLAGS_FOR_BUILD)" \
+ 	"CFLAGS_FOR_TARGET=$(CFLAGS_FOR_TARGET)" \
+--- libgm2/libm2iso/Makefile.in
++++ libgm2/libm2iso/Makefile.in
+@@ -447,7 +447,7 @@
+ 	"CC_FOR_BUILD=$(CC_FOR_BUILD)" \
+ 	"CC_FOR_TARGET=$(CC_FOR_TARGET)" \
+ 	"GM2_FOR_TARGET=$(GM2_FOR_TARGET)" \
+-	"CFLAGS=$(CFLAGS)" \
++	"CFLAGS=$(CFLAGS) -Wno-error=incompatible-pointer-types" \
+ 	"CXXFLAGS=$(CXXFLAGS)" \
+ 	"CFLAGS_FOR_BUILD=$(CFLAGS_FOR_BUILD)" \
+ 	"CFLAGS_FOR_TARGET=$(CFLAGS_FOR_TARGET)" \
+--- fixincludes/Makefile.in
++++ fixincludes/Makefile.in
+@@ -31,7 +31,7 @@
+ WARN_CFLAGS = @WARN_CFLAGS@ @WARN_PEDANTIC@ @WERROR@
+ LDFLAGS = @LDFLAGS@
+ INCLUDES = -I. -I$(srcdir) -I../include -I$(srcdir)/../include
+-FIXINC_CFLAGS = -DHAVE_CONFIG_H $(INCLUDES)
++FIXINC_CFLAGS = -Wno-error=incompatible-pointer-types -DHAVE_CONFIG_H $(INCLUDES)
+ 
+ # Directory where sources are, from where we are.
+ srcdir = @srcdir@


### PR DESCRIPTION
Here it is. I may consult with gcc upstream about the fortran and incompatible pointer type errors, but I used this to rebuild a lot of ports over the last weekend and everything seems to be working fine. I think any further changes can wait until gcc 16.2