### PR TITLE
appstream: add legacysupport pg for Leopard and below

### DIFF
--- a/gnome/appstream/Portfile
+++ b/gnome/appstream/Portfile
@@ -3,6 +3,9 @@
 PortSystem          1.0
 PortGroup           gobject_introspection 1.0
 PortGroup           meson 1.0
+PortGroup           legacysupport 1.1
+
+legacysupport.newest_darwin_requires_legacy 9
 
 name                appstream
 version             1.1.2


### PR DESCRIPTION
Needed to fix this:
```
:info:build In file included from /opt/local/include/libfyaml.h:81,
:info:build                  from ../AppStream-1.1.4/src/as-yaml.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-component-private.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-desktop-entry.c:36:
:info:build /opt/local/include/libfyaml/libfyaml-align.h: In function 'fy_align_alloc':
:info:build /opt/local/include/libfyaml/libfyaml-align.h:144:13: error: implicit declaration of function 'posix_memalign' [-Wimplicit-function-declaration]
:info:build   144 |         if (posix_memalign(&p, align, size))
:info:build       |             ^~~~~~~~~~~~~~
:info:build [2/96] /opt/local/bin/gcc-mp-16 -Isrc/libappstream.5.dylib.p -Isrc/ -I../AppStream-1.1.4/src -I/opt/local/include -I. -I../AppStream-1.1.4 -Isrc -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/libexec/openssl3/include -I/opt/local/include/libxmlb-2 -I/opt/local/include/libxml2 -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu17 -O0 -g -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=missing-declarations -Werror=return-type -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=declaration-after-statement -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -D_POSIX_C_SOURCE=201710L -D_DARWIN_C_SOURCE -DAS_COMPILATION -pipe -Os -Wno-error=incompatible-pointer-types -arch ppc -MD -MQ src/libappstream.5.dylib.p/as-file-monitor.c.o -MF src/libappstream.5.dylib.p/as-file-monitor.c.o.d -o src/libappstream.5.dylib.p/as-file-monitor.c.o -c ../AppStream-1.1.4/src/as-file-monitor.c
:info:build [3/96] /opt/local/bin/gcc-mp-16 -Isrc/libappstream.5.dylib.p -Isrc/ -I../AppStream-1.1.4/src -I/opt/local/include -I. -I../AppStream-1.1.4 -Isrc -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/libexec/openssl3/include -I/opt/local/include/libxmlb-2 -I/opt/local/include/libxml2 -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu17 -O0 -g -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=missing-declarations -Werror=return-type -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=declaration-after-statement -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -D_POSIX_C_SOURCE=201710L -D_DARWIN_C_SOURCE -DAS_COMPILATION -pipe -Os -Wno-error=incompatible-pointer-types -arch ppc -MD -MQ src/libappstream.5.dylib.p/as-cache.c.o -MF src/libappstream.5.dylib.p/as-cache.c.o.d -o src/libappstream.5.dylib.p/as-cache.c.o -c ../AppStream-1.1.4/src/as-cache.c
:info:build FAILED: [code=1] src/libappstream.5.dylib.p/as-cache.c.o
:info:build /opt/local/bin/gcc-mp-16 -Isrc/libappstream.5.dylib.p -Isrc/ -I../AppStream-1.1.4/src -I/opt/local/include -I. -I../AppStream-1.1.4 -Isrc -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/libexec/openssl3/include -I/opt/local/include/libxmlb-2 -I/opt/local/include/libxml2 -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu17 -O0 -g -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=missing-declarations -Werror=return-type -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=declaration-after-statement -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -D_POSIX_C_SOURCE=201710L -D_DARWIN_C_SOURCE -DAS_COMPILATION -pipe -Os -Wno-error=incompatible-pointer-types -arch ppc -MD -MQ src/libappstream.5.dylib.p/as-cache.c.o -MF src/libappstream.5.dylib.p/as-cache.c.o.d -o src/libappstream.5.dylib.p/as-cache.c.o -c ../AppStream-1.1.4/src/as-cache.c
:info:build In file included from /opt/local/include/libfyaml.h:81,
:info:build                  from ../AppStream-1.1.4/src/as-yaml.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-component-private.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-cache.c:44:
:info:build /opt/local/include/libfyaml/libfyaml-align.h: In function 'fy_align_alloc':
:info:build /opt/local/include/libfyaml/libfyaml-align.h:144:13: error: implicit declaration of function 'posix_memalign' [-Wimplicit-function-declaration]
:info:build   144 |         if (posix_memalign(&p, align, size))
:info:build       |             ^~~~~~~~~~~~~~
:info:build [4/96] /opt/local/bin/gcc-mp-16 -Isrc/libappstream.5.dylib.p -Isrc/ -I../AppStream-1.1.4/src -I/opt/local/include -I. -I../AppStream-1.1.4 -Isrc -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/libexec/openssl3/include -I/opt/local/include/libxmlb-2 -I/opt/local/include/libxml2 -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu17 -O0 -g -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=missing-declarations -Werror=return-type -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=declaration-after-statement -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -D_POSIX_C_SOURCE=201710L -D_DARWIN_C_SOURCE -DAS_COMPILATION -pipe -Os -Wno-error=incompatible-pointer-types -arch ppc -MD -MQ src/libappstream.5.dylib.p/as-utils.c.o -MF src/libappstream.5.dylib.p/as-utils.c.o.d -o src/libappstream.5.dylib.p/as-utils.c.o -c ../AppStream-1.1.4/src/as-utils.c
:info:build FAILED: [code=1] src/libappstream.5.dylib.p/as-utils.c.o
:info:build /opt/local/bin/gcc-mp-16 -Isrc/libappstream.5.dylib.p -Isrc/ -I../AppStream-1.1.4/src -I/opt/local/include -I. -I../AppStream-1.1.4 -Isrc -I/opt/local/include/glib-2.0 -I/opt/local/lib/glib-2.0/include -I/opt/local/libexec/openssl3/include -I/opt/local/include/libxmlb-2 -I/opt/local/include/libxml2 -fdiagnostics-color=always -Wall -Winvalid-pch -std=gnu17 -O0 -g -Werror=shadow -Werror=empty-body -Werror=strict-prototypes -Werror=missing-prototypes -Werror=implicit-function-declaration -Werror=pointer-arith -Werror=missing-declarations -Werror=return-type -Werror=int-conversion -Werror=incompatible-pointer-types -Werror=misleading-indentation -Werror=missing-include-dirs -Werror=declaration-after-statement -Wno-missing-field-initializers -Wno-error=missing-field-initializers -Wno-unused-parameter -Wno-error=unused-parameter -D_POSIX_C_SOURCE=201710L -D_DARWIN_C_SOURCE -DAS_COMPILATION -pipe -Os -Wno-error=incompatible-pointer-types -arch ppc -MD -MQ src/libappstream.5.dylib.p/as-utils.c.o -MF src/libappstream.5.dylib.p/as-utils.c.o.d -o src/libappstream.5.dylib.p/as-utils.c.o -c ../AppStream-1.1.4/src/as-utils.c
:info:build In file included from /opt/local/include/libfyaml.h:81,
:info:build                  from ../AppStream-1.1.4/src/as-yaml.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-component-private.h:28,
:info:build                  from ../AppStream-1.1.4/src/as-utils.c:48:
:info:build /opt/local/include/libfyaml/libfyaml-align.h: In function 'fy_align_alloc':
:info:build /opt/local/include/libfyaml/libfyaml-align.h:144:13: error: implicit declaration of function 'posix_memalign' [-Wimplicit-function-declaration]
:info:build   144 |         if (posix_memalign(&p, align, size))
:info:build       |             ^~~~~~~~~~~~~~
:info:build ninja: build stopped: subcommand failed.
:info:build Command failed:  cd "/opt/local/var/macports/build/appstream-74b8dbbd/work/build" && /opt/local/bin/ninja -j4 -v
:info:build Exit code: 1
:error:build Failed to build appstream: command execution failed
```