### PR TITLE
Set Libgcc/gcc max to 14 on i386 darwin 8

### DIFF
--- a/_resources/port1.0/compilers/gcc_compilers.tcl
+++ b/_resources/port1.0/compilers/gcc_compilers.tcl
@@ -3,8 +3,14 @@
 # https://trac.macports.org/ticket/57135
 # https://trac.macports.org/ticket/61636
 
-# GCC 14 on all systems
-lappend compilers macports-gcc-16 macports-gcc-14
+# GCC 16 and 14 on all systems except i386 tiger (GCC14 only) due to:
+# https://github.com/macos-powerpc/powerpc-ports/issues/187
+global os.arch
+if {${os.major} == 8 && ${os.arch} eq "i386"} {
+    lappend compilers macports-gcc-14
+} else {
+    lappend compilers macports-gcc-16 macports-gcc-14
+}
 
 # GCC 11 to GCC 13 on OSX10.6+
 if {${os.major} >= 10 || [option os.platform] ne "darwin"} {
@@ -28,7 +34,6 @@ if {${os.major} >= 10} {
     lappend compilers macports-gcc-devel
 }
 
-global os.arch
 if {${os.arch} eq "powerpc"} {
     lappend compilers macports-gcc-powerpc
 }

--- a/_resources/port1.0/compilers/gcc_dependencies.tcl
+++ b/_resources/port1.0/compilers/gcc_dependencies.tcl
@@ -2,7 +2,14 @@
 
 # GCC version providing the primary runtime
 # Note settings here *must* match those in the lang/libgcc port and compilers PG
-set gcc_main_version 16
+# GCC 16 and 14 on all systems except i386 tiger (GCC14 only) due to:
+# https://github.com/macos-powerpc/powerpc-ports/issues/187
+global os.arch
+if {${os.major} == 8 && ${os.arch} eq "i386"} {
+    set gcc_main_version 14
+} else {
+    set gcc_main_version 16
+}
 
 # compiler links against libraries in libgcc\d* and/or libgcc-*
 if {[vercmp ${gcc_version} 4.6] < 0} {

--- a/_resources/port1.0/compilers/gcc_dependencies.tcl
+++ b/_resources/port1.0/compilers/gcc_dependencies.tcl
@@ -4,8 +4,8 @@
 # Note settings here *must* match those in the lang/libgcc port and compilers PG
 # GCC 16 and 14 on all systems except i386 tiger (GCC14 only) due to:
 # https://github.com/macos-powerpc/powerpc-ports/issues/187
-global os.arch
-if {${os.major} == 8 && ${os.arch} eq "i386"} {
+global os.arch os.platform
+if {${os.platform} eq "darwin" && ${os.major} == 8 && ${os.arch} eq "i386"} {
     set gcc_main_version 14
 } else {
     set gcc_main_version 16

--- a/_resources/port1.0/group/compilers-1.0.tcl
+++ b/_resources/port1.0/group/compilers-1.0.tcl
@@ -92,7 +92,13 @@ if { ${os.arch} eq "arm" || ${os.platform} ne "darwin" } {
     if { [vercmp ${xcodeversion} < 16.0] && [vercmp ${xcodecltversion} < 16.0] } {
         lappend gcc_versions 10 11 12 13
     }
-    lappend gcc_versions 16 14 devel
+    # GCC 16 and 14 on all systems except i386 tiger (GCC14 only) due to:
+    # https://github.com/macos-powerpc/powerpc-ports/issues/187
+    if {${os.major} == 8 && ${os.arch} eq "i386"} {
+        lappend gcc_versions 14
+    } else {
+        lappend gcc_versions 16 14 devel
+    }
 } else {
     set gcc_versions [list]
     if { ${os.major} < 15 } {
@@ -111,7 +117,13 @@ if { ${os.arch} eq "arm" || ${os.platform} ne "darwin" } {
 }
 # GCC version providing the primary runtime
 # Note settings here *must* match those in the lang/libgcc port.
-set gcc_main_version 16
+# GCC 16 and 14 on all systems except i386 tiger (GCC14 only) due to:
+# https://github.com/macos-powerpc/powerpc-ports/issues/187
+if {${os.major} == 8 && ${os.arch} eq "i386"} {
+    set gcc_main_version 14
+} else {
+    set gcc_main_version 16
+}
 
 ui_debug "GCC versions for Darwin ${os.major} ${os.arch} - ${gcc_versions}"
 foreach ver ${gcc_versions} {

--- a/lang/gcc14/Portfile
+++ b/lang/gcc14/Portfile
@@ -439,7 +439,6 @@ proc dylib_list {location} {
 }
 
 if {${subport} eq ${libgccname}} {
-    
     # Libgcc16 fails to build on Tiger i386:
     # https://github.com/macos-powerpc/powerpc-ports/issues/187
     # So use libgcc14 instead.

--- a/lang/gcc14/Portfile
+++ b/lang/gcc14/Portfile
@@ -439,21 +439,37 @@ proc dylib_list {location} {
 }
 
 if {${subport} eq ${libgccname}} {
-    # No need to build as nothing that isn't provided by libgcc16
-    platforms       any
+    
+    # Libgcc16 fails to build on Tiger i386:
+    # https://github.com/macos-powerpc/powerpc-ports/issues/187
+    # So use libgcc14 instead.
+    if {${os.platform} eq "darwin" && ${os.major} == 8 && ${configure.build_arch} eq "i386"} {
+        
+        # MacPorts doesn't want us to use a matching libgcc, but we have nothing else we can use.
+        # Fixes circular dependency: libgcc (which is libgcc14) depends on libgcc14
+        depends_lib-delete port:libgcc
+        
+        # Allow using the libgcc14 compilation targets
+        global parts
+        set parts {libgcc}
+        
+    } else {
+        # No need to build as nothing that isn't provided by libgcc16
+        platforms       any
 
-    depends_run     path:share/doc/libgcc/README:libgcc
-    depends_lib
+        depends_run     path:share/doc/libgcc/README:libgcc
+        depends_lib
 
-    fetch.type      none
-    build           { }
-    use_configure   no
-    patchfiles
+        fetch.type      none
+        build           { }
+        use_configure   no
+        patchfiles
 
-    destroot {
-        set doc_dir ${destroot}${prefix}/share/doc/${subport}
-        xinstall -m 755 -d ${doc_dir}
-        system "echo ${subport} provides no runtime > ${doc_dir}/README"
+        destroot {
+            set doc_dir ${destroot}${prefix}/share/doc/${subport}
+            xinstall -m 755 -d ${doc_dir}
+            system "echo ${subport} provides no runtime > ${doc_dir}/README"
+        }
     }
 }
 
@@ -558,6 +574,18 @@ if {${subport} ne ${libcxxname}} {
     configure.universal_cxxflags
     configure.universal_ldflags
     configure.universal_args
+}
+
+if {${os.platform} eq "darwin" && ${os.major} == 8 && ${configure.build_arch} eq "i386"} {
+    notes "
+The gcc14 and libgcc14 ports have successfully built for i386 tiger. Because the
+compiler and libgcc is the same version, you must override file conflicts to complete 
+installation:
+
+sudo port -f activate gcc14
+sudo port install libgcc
+
+"
 }
 
 livecheck.type      regex

--- a/lang/libgcc/Portfile
+++ b/lang/libgcc/Portfile
@@ -32,7 +32,13 @@ variant universal   { }
 # Pick the gcc version that provides the primary runtime.
 # NOTE: The logic here must match that in the gccX ports *and*
 # that in _resources/port1.0/group/compilers-1.0.tcl
-set gcc_version     16
+# Libgcc16 fails to build on i386 Tiger:
+# https://github.com/macos-powerpc/powerpc-ports/issues/187
+if {${os.platform} eq "darwin" && ${os.major} == 8 && ${build_arch} eq "i386"} {
+    set gcc_version     14
+} else {
+    set gcc_version     16
+}
 
 depends_lib         port:libgcc${gcc_version}
 


### PR DESCRIPTION
Due to libgcc16 not currently building on i386 tiger (https://github.com/macos-powerpc/powerpc-ports/issues/187), we should limit libgcc to 14 and maximum gcc to gcc14 on this configuration until it is resolved.

I think this is the cleanest way to support this, let me know your thoughts. I believe this is the correct way to allow GCC to build with matching libgcc14 (this is usually a problem, yes?), but you are much more familiar with toolchains then I. I tried to go off of https://github.com/macos-powerpc/powerpc-ports/commit/cff9f9cf48a7637f9b430f5edaa1053ad5e93c01 , so please let me know if this seems correct.

I'm going to rebuild everything from nothing just to sanity check this as well and report back.

Effectively, intel tiger now requests:

alexs-computer-2:~ alex$ sudo port rdeps gcc14
The following ports are dependencies of gcc14 @14.3.0_0:
  xz
    gettext
      xz-bootstrap
        apple-gcc42
          gcc_select
      ncurses
      gettext-tools-libs
        libiconv
          gperf
        libtextstyle
        gettext-runtime
  texinfo
    help2man
      perl5.34
        db48
        gdbm
          readline
      p5.34-locale-gettext
    libunistring
      autoconf
        m4-bootstrap
      automake
      libtool
        m4
      gmake
        lzip
  gcc10-bootstrap
    gcc7-bootstrap
      cctools
        libunwind-headers
      ld64
        ld64-97
          libmacho-headers
  flex
  gmp
  isl
  libmpc
    mpfr
  zlib
  zstd
    lz4
  libgcc14
alexs-computer-2:~ alex$ 

PowerPC tiger now requests:
The following ports are dependencies of gcc14 @14.3.0_0:
  xz
    gettext
      xz-bootstrap
        apple-gcc42
          gcc_select
      ncurses
      gettext-tools-libs
        libiconv
          gperf
        libtextstyle
        gettext-runtime
  texinfo
    help2man
      perl5.34
        db48
        gdbm
          readline
      p5.34-locale-gettext
    libunistring
      autoconf
        m4-bootstrap
      automake
      libtool
        m4
      gmake
        lzip
  gcc10-bootstrap
    gcc7-bootstrap
      cctools
        libunwind-headers
      ld64
        ld64-97
          libmacho-headers
  flex
  gmp
  isl
  libmpc
    mpfr
  zlib
  zstd
    lz4
  libgcc14
    libgcc
      libgcc16