### PR TITLE
enable no_compact_unwind to fix intel tiger gcc16

### DIFF
--- a/lang/gcc16/Portfile
+++ b/lang/gcc16/Portfile
@@ -276,6 +276,14 @@ platform darwin 8 {
     patchfiles-append   darwin8-core-count.patch
     # surpress some incompatible-pointer-type errors where needed
     patchfiles-append   darwin8-pointer-types.patch
+
+    # Since ld64-97.17 on Tiger supports -no_compact_unwind unlike the default linker, it can be enabled in order to disable
+    # the usage of compact unwind. Compact unwind can not be used when build gcc16 due to it's complexity, so fall back to 
+    # DWARF. GCC fixed this in their PR41260 workaround, but made it require 10.6+ minimum. Changes it to no minimum.
+    # Fixes error: ld: 24-bit pointer diff out of range in unwind info in unwind info from a681 and for other executables.
+    if {${configure.build_arch} eq "i386"} {
+        patchfiles-append   darwin8-no_compact_unwind.patch
+    }
 }
 
 configure.env-append \

--- a/lang/gcc16/files/darwin8-no_compact_unwind.patch
+++ b/lang/gcc16/files/darwin8-no_compact_unwind.patch
@@ -1,0 +1,11 @@
+--- gcc/config/darwin.h.orig	2026-08-04 00:30:54.000000000 -0600
++++ gcc/config/darwin.h	2026-08-04 00:31:07.000000000 -0600
+@@ -396,7 +396,7 @@
+ 
+ #define DARWIN_NOCOMPACT_UNWIND \
+ "%{!fuse-ld=lld: \
+-    %:version-compare(>= 10.6 mmacosx-version-min= -no_compact_unwind)}"
++    -no_compact_unwind}"
+ 
+ /* In Darwin linker specs we can put -lcrt0.o and ld will search the library
+    path for crt0.o or -lcrtx.a and it will search for libcrtx.a.  As for


### PR DESCRIPTION
Soo... this was very interesting to fix. As we know, right now on Intel Tiger during the compile of gcc 16/libgcc 16 we get these errors during the compile (I will attach the full error log here for historical reasons, but the important ones out of it are):

ld: 24-bit pointer diff out of range in unwind info in unwind info from cc1
ld: 24-bit pointer diff out of range in unwind info in unwind info from f951
ld: 24-bit pointer diff out of range in unwind info in unwind info from cc1plus
ld: 24-bit pointer diff out of range in unwind info in unwind info from a681
collect2: error: ld returned 1 exit status

See https://github.com/macos-powerpc/powerpc-ports/issues/187 . So what is this error? Why did this not happen on PowerPC? I have these answers.

So Apple has an alternative format to DWARF called compact_unwind. Both of these effectively however have the same goal: to provide information to debuggers, crash profilers, stack traces. The idea with compact_unwind is to give you smaller executables that still contain unwind data using a different method of representing the needed data. See https://jezng.com/macho-notes/unwind-info.html and https://llvm.org/devmtg/2026-04/slides/lightning_talk/lightning_talk_engelke.pdf. 

You can read more about compact_unwind here: https://faultlore.com/blah/compact-unwinding/. Specifically this kinda goes over it and the section after is about DWARF: https://faultlore.com/blah/compact-unwinding/#the-compact-unwinding-format.

OK, so anyways the actual bug. Our error is ld: 24-bit pointer diff out of range in unwind info. What does this mean? There is literally too much unwind info to encode with in a 24-bit pointer for functions in these executables. This wasn't a problem in GCC14 because it was still under the threshold for Intel AND Power. But now (I haven't confirmed it but others have that GCC16 builds no problem on Power) Intel is confirmed over the limit of what compact_unwind can support (which is insane to think about). Another win for Power in a way, but it's kind of a warning that we are probably brushing up against the limit of what can be encoded in compact_unwind when building gcc in Power too probably.

So interestingly, this was already causing other problems in Mac OS X 10.6 and up. See https://github.com/iains/gcc-16-branch/blob/576cb8311ed9b90f4346c01fa0557eb62aa73f61/gcc/config/darwin.h#L390 which references https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41260#c38. Essentially compact_unwind is not the right 'tool' for GCC specifically, DWARF is the better fit.

So, did you see it yet? If you missed it, this is our problem https://github.com/iains/gcc-16-branch/blob/576cb8311ed9b90f4346c01fa0557eb62aa73f61/gcc/config/darwin.h#L397 . While initially introduced for the above linked issue, the problem it solves is the in the end the same. Compact unwind should not be used for unwind info when building gcc (this of course has zero effect on what you build with it after it is compiled, this is about gcc itself and what type of unwind info it will have in it's executables). When turned off, it goes back to DWARF fallback at least according to https://clang.llvm.org/docs/UsersManual.html:

"no-compact-unwind - Only emit DWARF unwind when compact unwind encodings aren’t available. This is the default for arm64."

The reason I'm referencing llvm when Tiger is using LD64_97 from MacPorts is because of 2 reasons.

1) Xcode v2.5's ld does NOT work with this flags. Luckily for us, macports does:

alexs-computer-2:/opt/local/var/macports/sources/tigerports.com/macports/release/lang/gcc16/files alex$ strings /usr/bin/ld | grep no_compact_unwind
alexs-computer-2:/opt/local/var/macports/sources/tigerports.com/macports/release/lang/gcc16/files alex$ /usr/bin/ld -v
Apple Computer, Inc. version cctools-622.9~2
alexs-computer-2:/opt/local/var/macports/sources/tigerports.com/macports/release/lang/gcc16/files alex$ strings /opt/local/bin/ld | grep no_compact_unwind
-no_compact_unwind
alexs-computer-2:/opt/local/var/macports/sources/tigerports.com/macports/release/lang/gcc16/files alex$ /opt/local/bin/ld -v
@(#)PROGRAM:ld  PROJECT:ld64-97.17
configured to support archs: i386 x86_64 ppc ppc64 armv6 armv7
alexs-computer-2:/opt/local/var/macports/sources/tigerports.com/macports/release/lang/gcc16/files alex$ 

2) LD64_97 man pages have this completely undocumented, the best thing I can get is LLVM documentation but the flags was birthed in LD64_97 first with this specific syntax.

So that GCC code: https://github.com/iains/gcc-16-branch/blob/576cb8311ed9b90f4346c01fa0557eb62aa73f61/gcc/config/darwin.h#L397 it only sends that flag if Mac OS X version is 10.6 or higher. This is correct under the assumption that the original Xcode v2.5 linker doesn't support it. But because we need the newer ld64_97 anyways at this point to compile GCC16, it is no longer necessary for this check to exist.

The interesting thing is PowerPC 10.6 is already using DWARF instead of compact_unwind. 10.4 and 10.5 are the only ones that still try to use compact_unwind info. With the current setup of things to compile GCC16, it just makes sense to remove the version check entirely. This is what I'm gonna suggest to upstream, but here I'm only applying it for darwin8 i386 to be conservative. I can change this if you think it would be better to do it regardless.

