### PR TITLE
gawk: remove upstreamed patches

### DIFF
--- a/lang/gawk/Portfile
+++ b/lang/gawk/Portfile
@@ -23,10 +23,7 @@ checksums               rmd160  929ac99cc1bcb8015b7cc0701f29fdf812833c75 \
                         sha256  07f6f7342b7febe4313fc2c2542ad93d64fe20ad8717200109f105a826f5fd37 \
                         size    3838416
 
-# https://trac.macports.org/ticket/72587
-patchfiles              patch-_NSGetExecutablePath.diff
-
-patchfiles-append       patch-node_align.diff
+patchfiles              patch-node_align.diff
 
 if [string match *gcc-4.* ${configure.compiler}] {
     patchfiles-append   patch-gcc4.diff
@@ -43,17 +40,8 @@ configure.args          --with-libiconv-prefix=${prefix} \
                         ac_cv_prog_AWK=awk
 
 platform darwin {
-    # https://trac.macports.org/ticket/65944
-    if {${os.major} < 10} {
-        post-patch {
-            reinplace   "s:-Xlinker -no_pie::" ${worksrcpath}/configure
-        }
-    }
     if {${os.major} < 9} {
         # Hopefully upstream fixes this silly bug in the next release...
-        patchfiles-replace \
-                        patch-_NSGetExecutablePath.diff \
-                        patch-tiger.diff
         configure.cppflags-append \
                         -D__DARWIN_UNIX03
     }


### PR DESCRIPTION
Since Tiger patches were upstreamed, this is now failing to patch it. The reinpalce also is not needed anymore (no match).

