### PR TITLE
icu: use gmake port on tiger to prevent race condition in multiple job make

### DIFF
--- a/devel/icu/Portfile
+++ b/devel/icu/Portfile
@@ -161,6 +161,11 @@ if {${subport} eq ${name} || ${subport} eq "${name}-lx"} {
 
     platform darwin 8 {
         patchfiles-append patch-common-putil.cpp.diff
+        # Xcode 2.5 gnumake has race conditon with multiple threads,
+        # with 4 cores the below happens after clean->uninstall->install randomly:
+        # couldn't write bundle /root.res. Error:U_FILE_ACCESS_ERRORf
+        depends_build-append port:gmake
+        build.cmd ${prefix}/bin/gmake
     }
 
     platform freebsd {


### PR DESCRIPTION
Tested 7 times and issue is gone. When using Xcode 2.5 GNUmake it would happen after almost every other compile.