### PR TITLE
MPlayer: enable SDL support, revbump

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -7,7 +7,7 @@ conflicts           mplayer-devel
 version             1.5.0
 distname            ${name}-1.5
 livecheck.version   1.5
-revision            3
+revision            4
 categories          multimedia
 license             GPL-2+
 maintainers         {jeremyhu @jeremyhu} openmaintainer
@@ -47,6 +47,7 @@ depends_lib-append  port:aom \
                     port:libxml2 \
                     port:lzo2 \
                     port:ncurses \
+                    port:libsdl2 \
                     path:lib/libspeex.dylib:speex \
                     port:zlib
 
@@ -60,14 +61,15 @@ if {${os.platform} eq "darwin" && ${os.major} > 22} {
 configure.args      --cc=${configure.cc} \
                     --host-cc=${configure.cc} \
                     --enable-freetype \
-                    --enable-menu
+                    --enable-menu \
+                    --enable-sdl
 
 foreach option {
 
 3dfx aa alsa apple-ir arts bl bluray caca cddb cdparanoia dart dga1 dga2 direct3d directfb \
 directx dvb dvdnav dvdread dxr2 dxr3 esd faac faad fbdev ggi gif gui jack joystick kai kva \
 ladspa liba52 libbs2b libdca libdv libnut libvorbis lirc live macosx-finder mad mga mng \
-mpg123 musepack nas nemesi ossaudio pulse pvr qtx quartz radio radio-capture s3fb sdl \
+mpg123 musepack nas nemesi ossaudio pulse pvr qtx quartz radio radio-capture s3fb \
 sgiaudio smb sndio sunaudio svga tdfxfb tdfxvid theora toolame tv-bsdbt848 tv-dshow \
 tv-v4l1 tv-v4l2 twolame v4l2 vdpau vesa vidix vstream wii win32dll win32waveout x11 \
 x264 xmga xmms xss xv xvid xvmc xvr100 zr


### PR DESCRIPTION
If there was a good reason to disable SDL support by default, I am open to doing this as a variant or making it Tiger specific. However, without SDL support, Tiger has no -vo option that really works. And I have a hard time seeing why the option of -vo SDL (and -vo gl if libsdl-cocoa is built with +opengl) is a bad thing for all platforms to have.