### PR TITLE
python314: disable avx on tiger i386 build

### DIFF
--- a/lang/python314/Portfile
+++ b/lang/python314/Portfile
@@ -5,7 +5,7 @@ PortSystem          1.0
 name                python314
 
 # Remember to keep py314-tkinter and py314-gdbm's versions sync'd with this
-version             3.14.7
+version             3.14.6
 
 set branch          [join [lrange [split ${version} .] 0 1] .]
 categories          lang
@@ -21,9 +21,9 @@ master_sites        ${homepage}/ftp/python/${version}/
 
 distname            Python-${version}
 use_xz              yes
-checksums           rmd160  94cfa8a811771fd445a4efb69eed1d93f31f5f41 \
-                    sha256  3b48dac8fb59f62eaa67ac83c1eb12bda1b7a08406dd286e252c11a66be27f81 \
-                    size    24053924
+checksums           rmd160  147551e12e7be5ce6ace0e10fdcdbaa1e7e487e8 \
+                    sha256  143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63 \
+                    size    23921184
 
 patchfiles          patch-configure.diff \
                     Makefile.pre.in.patch \
@@ -109,6 +109,13 @@ test.run            yes
 test.target         test
 
 destroot.target     frameworkinstall maninstall
+
+# Darwin 8 assembler can't generate these instructions, but gcc16 will try 
+# Unless all of these are set.
+if {${os.platform} eq "darwin" && ${os.major} == 8 && ${configure.build_arch} eq "i386"} {
+    configure.cflags-append "-D__AVX__=0 -D__AVX2__=0"
+    configure.cppflags-append "-D__AVX__=0 -D__AVX2__=0"
+}
 
 subport python314-freethreading {
     PortGroup       legacysupport 1.1


### PR DESCRIPTION
Python really wants to turn on AVX when using gcc16.