### PR TITLE
cmake: fix distfile name on case-sensitive fs

### DIFF
--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -41,7 +41,7 @@ checksums           rmd160  b08518899f2fd701a28e4428ed73b37bd5b968b0 \
                     sha256  5f3fd5a54dfa65602bdbed64f981a72673cc19f2d304cc2955cf0dfa0cfd8272 \
                     size    11715065
 github.tarball_from releases
-
+distname            cmake-${version}
 dist_subdir         ${my_name}
 
 # TODO: switch to the new ABI if that works, then drop wrappers?

--- a/devel/cmake/Portfile
+++ b/devel/cmake/Portfile
@@ -41,7 +41,7 @@ checksums           rmd160  b08518899f2fd701a28e4428ed73b37bd5b968b0 \
                     sha256  5f3fd5a54dfa65602bdbed64f981a72673cc19f2d304cc2955cf0dfa0cfd8272 \
                     size    11715065
 github.tarball_from releases
-distname            cmake-${version}
+distname            ${my_name}-${version}
 dist_subdir         ${my_name}
 
 # TODO: switch to the new ABI if that works, then drop wrappers?


### PR DESCRIPTION
I use JHFS+ case-sensitive. When this requests the distfile (at least if github fetch fails, which it always will in my setup) it tries to download CMake-$version. But i.e. distfiles.macports.com has this mirrored as all lowercase https://distfiles.macports.com/cmake/ , and so does everything else... I would imagine fetch would fail irregardless of if one has a case-sensitive fs as well.