### PR TITLE
Orc: tiger specific and i386 fixes

### DIFF
--- a/devel/orc/Portfile
+++ b/devel/orc/Portfile
@@ -1,0 +1,42 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           meson 1.0
+PortGroup           muniversal 1.1
+
+name                orc
+version             0.4.42
+revision            0
+
+checksums           rmd160  bd1a19d5ff4e25ecc2b9cfdf0ce61f3175f438d7 \
+                    sha256  7ec912ab59af3cc97874c456a56a8ae1eec520c385ec447e8a102b2bd122c90c \
+                    size    280792
+
+description         Orc - The Oil Runtime Compiler
+long_description    Orc is a library and set of tools for compiling \
+                    and executing very simple programs that operate on arrays of data.
+
+maintainers         nomaintainer
+categories          devel
+license             BSD
+homepage            https://gstreamer.freedesktop.org/modules/orc.html
+master_sites        https://gstreamer.freedesktop.org/src/orc/
+
+use_xz              yes
+
+# https://trac.macports.org/ticket/70658
+compiler.c_standard 2011
+
+# Undefined symbols for architecture x86_64: "__xgetbv"
+# uses newer assembly features on Intel
+compiler.blacklist-append \
+                    {clang < 1100}
+
+test.run            yes
+
+platform darwin 8 {
+    # meson on Tiger cannot use rpaths, so we workaround with this to find dylib
+    build.env-append       "DYLD_LIBRARY_PATH=${build_dir}/${name}"
+    test.env-append        "DYLD_LIBRARY_PATH=${build_dir}/${name}:${build_dir}/${name}-test"
+    destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/${name}"
+}

--- a/devel/orc/Portfile
+++ b/devel/orc/Portfile
@@ -39,4 +39,16 @@ platform darwin 8 {
     build.env-append       "DYLD_LIBRARY_PATH=${build_dir}/${name}"
     test.env-append        "DYLD_LIBRARY_PATH=${build_dir}/${name}:${build_dir}/${name}-test"
     destroot.env-append    "DYLD_LIBRARY_PATH=${build_dir}/${name}"
+    patchfiles-append \
+        orc_orccompiler.c_tiger.diff
+
+    if {${configure.build_arch} eq "i386"} {
+        patchfiles-append \
+            orc_orcprogram-x86.c_tiger.diff
+    }
+}
+
+if {${configure.build_arch} eq "i386"} {
+    patchfiles-append \
+        orc_orccpu-x86.c_i386.diff
 }

--- a/devel/orc/files/orc_orccompiler.c_tiger.diff
+++ b/devel/orc/files/orc_orccompiler.c_tiger.diff
@@ -1,0 +1,15 @@
+--- orc/orccompiler.c.orig	2026-08-11 17:25:11.000000000 -0600
++++ orc/orccompiler.c	2026-08-11 17:32:52.000000000 -0600
+@@ -15,7 +15,11 @@
+ /* TARGET_OS_OSX is not defined on older macOS, but is always defined
+    to 0 for Apple mobile targets. */
+ #if !defined(TARGET_OS_OSX) || TARGET_OS_OSX
+-#include <libkern/OSCacheControl.h>
++#include <AvailabilityMacros.h>
++// Not available in Tiger.
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
++#include  <libkern/OSCacheControl.h>
++#endif
+ #endif
+ #endif
+ 

--- a/devel/orc/files/orc_orccpu-x86.c_i386.diff
+++ b/devel/orc/files/orc_orccpu-x86.c_i386.diff
@@ -1,0 +1,19 @@
+--- orc/orccpu-x86.c.orig	2026-08-11 22:06:52.000000000 -0600
++++ orc/orccpu-x86.c	2026-08-11 22:12:09.000000000 -0600
+@@ -248,7 +248,15 @@
+ static orc_uint32 ORC_TARGET_XSAVE
+ get_xcr0 (void)
+ {
+-  return _xgetbv(0);
++#if defined(__APPLE__) && defined(__i386__)
++// This is expecting _xgetbv in some form to exist so that features can be
++// checked for, but on older Intel CPUs it does not, so return feature can
++// not be used by returning zero always.
++// https://stackoverflow.com/questions/72522885/are-the-xgetbv-and-cpuid-checks-sufficient-to-guarantee-avx2-support
++    return 0;
++#else  
++    return _xgetbv(0);
++#endif
+ }
+ #endif
+ 

--- a/devel/orc/files/orc_orcprogram-x86.c_tiger.diff
+++ b/devel/orc/files/orc_orcprogram-x86.c_tiger.diff
@@ -1,0 +1,37 @@
+--- orc/orcprogram-x86.c.orig	2026-08-11 17:29:40.000000000 -0600
++++ orc/orcprogram-x86.c	2026-08-11 21:33:42.000000000 -0600
+@@ -13,8 +13,12 @@
+ #include <orc/orcinternal.h>
+ 
+ #if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++// Not available in Tiger.
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
+ #include  <libkern/OSCacheControl.h>
+ #endif
++#endif
+ 
+ #if defined(_WIN32)
+ #include <windows.h>
+@@ -1219,8 +1223,21 @@
+ orc_x86_flush_cache (OrcCode *code)
+ {
+ #if defined(__APPLE__)
++// https://gcc.gnu.org/onlinedocs/gcc-4.2.3/gcc/X86-Built_002din-Functions.html
++// https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sys_dcache_flush.3.html
++// sys_icache_invalidate and sys_dcache_flush were introduced in Mac OS X 10.5.
++// On Intel, sys_icace_invalidate is a no-op. GCC builtin can be used for dcache.
++// However GCC builtin only does 64 bytes. We need to do it for code->code_size.
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++    unsigned char *p = (unsigned char *)code->code;
++    size_t i;
++    for (i = 0; i < code->code_size; i += 64) {
++      __builtin_ia32_clflush(p + i);
++    }
++#else
+   sys_dcache_flush(code->code, code->code_size);
+   sys_icache_invalidate(code->exec, code->code_size);
++#endif
+ #elif defined (_WIN32)
+   HANDLE h_proc = GetCurrentProcess();
+ 


### PR DESCRIPTION
fixes issues with older intel CPUs, and tiger. This is actually broken on anything remotely old in mainstream macports due to a variaty of reasons. One of them is the instruction that checks if things like AVX is available, is itself not found on older CPUs and there is no fallback.