### PR TITLE
libjpeg-turbo: blacklist apple gcc on intel

### DIFF
--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -47,6 +47,9 @@ if {${universal_possible} && [variant_isset universal]} {
 } elseif {${configure.build_arch} in {i386 x86_64}} {
     depends_build-append port:nasm
     configure.env       ASM_NASM=${prefix}/bin/nasm
+    # Need a newer gcc (such as gcc16) to provide this. Otherwise:
+    # error: immintrin.h: No such file or directory.
+    compiler.blacklist apple-gcc-4.2 *gcc-4.0
 } elseif {${configure.build_arch} eq "ppc"} {
     if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
         configure.args-append   -DWITH_SIMD=OFF

--- a/graphics/libjpeg-turbo/Portfile
+++ b/graphics/libjpeg-turbo/Portfile
@@ -49,7 +49,7 @@ if {${universal_possible} && [variant_isset universal]} {
     configure.env       ASM_NASM=${prefix}/bin/nasm
     # Need a newer gcc (such as gcc16) to provide this. Otherwise:
     # error: immintrin.h: No such file or directory.
-    compiler.blacklist apple-gcc-4.2 *gcc-4.0
+    compiler.blacklist *gcc-4.2 *gcc-4.0
 } elseif {${configure.build_arch} eq "ppc"} {
     if {[catch {sysctl hw.vectorunit} result] || $result == 0} {
         configure.args-append   -DWITH_SIMD=OFF


### PR DESCRIPTION
Nasm needs a new gcc, gcc16 works so we don't need to do the same thing as power does (below this) and can keep asm optimizations.