### PR TITLE
libdeflate: add more assembler checks for i386

### DIFF
--- a/archivers/libdeflate/Portfile
+++ b/archivers/libdeflate/Portfile
@@ -34,6 +34,15 @@ github.tarball_from releases
 # https://github.com/ebiggers/libdeflate/commit/a83fb24e1cb0ec6b6fd53446c941013edf055192
 compiler.blacklist-append   *gcc-4.* {clang < 800} {macports-clang-3.[0-8]}
 
+# Libdeflate is aware that older binutils (like those in Xcode v2.5) do not 
+# support modern x86_64 instructions such as AVX512VNNI and AVX_VNNI and will
+# not use them if it detects the as will error out. This is expanded
+# to more instructions (AVX2, PCLMULQDQ, BMI2) for i386 to work.
+# See https://github.com/ebiggers/libdeflate/issues/433.
+if {${configure.build_arch} eq "i386"} {
+    patchfiles-append    additional_binutils_checks_i386.diff
+}
+
 configure.args-append \
                     -DLIBDEFLATE_BUILD_TESTS=1
 

--- a/archivers/libdeflate/additional_binutils_checks_i386.diff
+++ b/archivers/libdeflate/additional_binutils_checks_i386.diff
@@ -1,0 +1,70 @@
+--- CMakeLists.txt.orig	2026-08-21 02:05:04.000000000 -0600
++++ CMakeLists.txt	2026-08-21 02:19:08.000000000 -0600
+@@ -155,6 +155,13 @@
+             # Set LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_AVX_VNNI if needed.
+             check_assembler_support(AVX_VNNI "{vex} vpdpbusd %ymm0, %ymm0, %ymm0")
+         endif()
++	# GCC 4.9 is the minimum, and supports all of these instructions.
++        # Set LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_AVX2 if needed.
++        check_assembler_support(AVX2 "vpxor %ymm0, %ymm0, %ymm0")
++        # Set LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_PCLMULQDQ if needed.
++        check_assembler_support(PCLMULQDQ "pclmulqdq $0, %xmm0, %xmm0")
++        # Set LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_BMI2 if needed.
++        check_assembler_support(BMI2 "shlx %eax, %eax, %eax")
+     elseif(${machine} MATCHES "^aarch64")
+         if(${CMAKE_C_COMPILER_VERSION} VERSION_GREATER_EQUAL 8.1)
+             # Set LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_DOTPROD if needed.
+--- lib/x86/adler32_impl.h.orig	2026-08-14 23:15:39.000000000 -0600
++++ lib/x86/adler32_impl.h	2026-08-14 23:17:32.000000000 -0600
+@@ -40,6 +40,7 @@
+ #  define USE_AVX512		0
+ #  include "adler32_template.h"
+ 
++#  if !defined(LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_AVX2)
+ #  define adler32_x86_avx2	adler32_x86_avx2
+ #  define SUFFIX			   _avx2
+ #  define ATTRIBUTES		_target_attribute("avx2")
+@@ -48,6 +49,7 @@
+ #  define USE_AVX512		0
+ #  include "adler32_template.h"
+ #endif
++#endif
+ 
+ /*
+  * AVX-VNNI implementation.  This is used on CPUs that have AVX2 and AVX-VNNI
+--- lib/x86/crc32_impl.h.orig	2026-08-14 23:51:25.000000000 -0600
++++ lib/x86/crc32_impl.h	2026-08-14 23:56:10.000000000 -0600
+@@ -48,6 +48,7 @@
+  * PCLMULQDQ implementation.  This targets PCLMULQDQ+SSE4.1, since in practice
+  * all CPUs that support PCLMULQDQ also support SSE4.1.
+  */
++#if !defined(LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_PCLMULQDQ)
+ #  define crc32_x86_pclmulqdq	crc32_x86_pclmulqdq
+ #  define SUFFIX			 _pclmulqdq
+ #  define ATTRIBUTES		_target_attribute("pclmul,sse4.1")
+@@ -67,6 +68,7 @@
+ #  define USE_AVX512		0
+ #  include "crc32_pclmul_template.h"
+ #endif
++#endif
+ 
+ /*
+  * VPCLMULQDQ/AVX2 implementation.  This is used on CPUs that have AVX2 and
+--- lib/x86/decompress_impl.h.orig	2026-08-15 00:39:16.000000000 -0600
++++ lib/x86/decompress_impl.h	2026-08-15 00:40:00.000000000 -0600
+@@ -16,6 +16,7 @@
+  * intrinsics.  It seems to be fixed in VS2022.  Hence, use MSVC_PREREQ(1930).
+  */
+ #if defined(__GNUC__) || defined(__clang__) || MSVC_PREREQ(1930)
++#if !defined(LIBDEFLATE_ASSEMBLER_DOES_NOT_SUPPORT_BMI2) 
+ #  define deflate_decompress_bmi2	deflate_decompress_bmi2
+ #  define FUNCNAME			deflate_decompress_bmi2
+ #  define ATTRIBUTES			_target_attribute("bmi2")
+@@ -38,6 +39,7 @@
+ #  endif
+ #  include "../decompress_template.h"
+ #endif
++#endif
+ 
+ #if defined(deflate_decompress_bmi2) && HAVE_BMI2_NATIVE
+ #define DEFAULT_IMPL	deflate_decompress_bmi2


### PR DESCRIPTION
Libdeflate already does this, but it falls short because it still is expecting a semi-modern Intel 64 bit CPU: https://github.com/ebiggers/libdeflate/issues/433