### PR TITLE
libsndfile: gcc16 build fix

### DIFF
--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -1,0 +1,78 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           muniversal 1.0
+PortGroup           legacysupport 1.1
+
+# strnlen
+legacysupport.newest_darwin_requires_legacy 10
+
+github.setup        libsndfile libsndfile 1.2.2
+revision            2
+
+checksums           rmd160  ee0d08d6542dd33fa7e931203ab4af513c43fe2d \
+                    sha256  3799ca9924d3125038880367bf1468e53a1b7e3686a934f098b7e1d286cdb80e \
+                    size    730760
+
+categories          audio
+maintainers         nomaintainer
+
+description         read and write files containing sampled sound
+long_description    \
+    libsndfile is a C library for reading and writing files \
+    containing sampled sound through one standard library interface. \
+    libsndfile has the following main features: \
+    ability to read and write a large number of file formats, \
+    a simple, elegant and easy to use API, \
+    and on the fly format conversion.
+license             LGPL-2.1+
+homepage            https://libsndfile.github.io/libsndfile/
+
+github.tarball_from releases
+use_xz              yes
+
+depends_build       path:bin/pkg-config:pkgconfig
+depends_lib         port:flac \
+                    port:libogg \
+                    port:libvorbis \
+                    port:libopus \
+                    port:mpg123 \
+                    port:lame
+
+configure.args \
+    --disable-alsa \
+    --disable-octave \
+    --disable-silent-rules \
+    --disable-sqlite \
+    --disable-test-coverage \
+    --enable-external-libs
+
+if {${configure.build_arch} in [list i386 x86_64]} {
+    # This is an Intel-specific issue: sources use immintrin.h,
+    # and Xcode gcc does not have it.
+    compiler.blacklist-append *gcc-4.0 *gcc-4.2
+}
+
+variant no_external_libs conflicts experimental description {Disable FLAC, Ogg, Vorbis and Opus support} {
+    depends_build-delete    port:pkgconfig
+    depends_lib-delete      port:flac \
+                            port:libogg \
+                            port:libvorbis \
+                            port:libopus \
+                            port:mpg123 \
+                            port:lame
+    configure.args-replace  --enable-external-libs --disable-external-libs
+}
+
+variant experimental conflicts no_external_libs description {Enable experimental Speex support} {
+    depends_lib-append      port:speex
+    configure.args-append   --enable-experimental
+}
+
+variant octave description {Enable support for Octave} {
+    depends_lib-append      path:bin/octave:octave
+    configure.args-replace  --disable-octave --enable-octave
+}
+
+github.livecheck.regex  {([0-9.]+)}

--- a/audio/libsndfile/Portfile
+++ b/audio/libsndfile/Portfile
@@ -54,6 +54,12 @@ if {${configure.build_arch} in [list i386 x86_64]} {
     compiler.blacklist-append *gcc-4.0 *gcc-4.2
 }
 
+# GCC 16 std default is too new:
+# alac_decoder.c:42:9: error: cannot use keyword 'false' as enumeration constant
+if {[string match "macports-gcc-16" ${configure.compiler}]} {
+    configure.cflags-append -std=gnu17
+}
+
 variant no_external_libs conflicts experimental description {Disable FLAC, Ogg, Vorbis and Opus support} {
     depends_build-delete    port:pkgconfig
     depends_lib-delete      port:flac \


### PR DESCRIPTION
Uses it's own def of true/false bool. Which gcc16 refuses to use under it's default flags for newer c standard