### PR TITLE
libxkbcommon: fix x11 subport on tiger

### DIFF
--- a/devel/libxkbcommon/Portfile
+++ b/devel/libxkbcommon/Portfile
@@ -1,0 +1,87 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           meson 1.0
+
+# When building universal the meson test for unistd.h fails because
+# clang: error: cannot use 'cpp-output' output with multiple -arch options
+# leading to build failure later when unistd.h doesn't get included if
+# implicit function declarations are not allowed (Xcode 12+).
+PortGroup           muniversal 1.0
+
+github.setup        xkbcommon libxkbcommon 1.7.0 xkbcommon-
+# Change github.tarball_from to 'releases' or 'archive' next update
+github.tarball_from tarball
+checksums           rmd160  08ef850e66c8ec448725fb7c4f286ee30ba691cf \
+                    sha256  65782f0a10a4b455af9c6baab7040e2f537520caa2ec2092805cdfd36863b247 \
+                    size    534312
+
+categories          devel
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             MIT
+
+description         library to handle keyboard descriptions
+
+long_description    ${name} is a {*}${description}, including loading them from \
+                    disk, parsing them and handling their state. It's mainly \
+                    meant for client toolkits, window systems, and other \
+                    system applications. It is also used by some XCB \
+                    applications for proper keyboard support.
+
+homepage            https://xkbcommon.org
+master_sites        ${homepage}/download/
+use_xz              yes
+
+depends_build-append \
+                    port:bison \
+                    path:bin/pkg-config:pkgconfig \
+                    port:xorg-util-macros
+
+compiler.c_standard 2011
+
+configure.args      -Ddefault_library=both \
+                    -Denable-docs=false \
+                    -Denable-wayland=false \
+                    -Denable-x11=false
+
+if {${subport} eq ${name}} {
+    revision        1
+
+    depends_lib-append \
+                    port:libxml2 \
+                    port:xkeyboard-config
+}
+
+subport ${name}-x11 {
+    revision        0
+
+    PortGroup       legacysupport 1.0
+
+    # strnlen
+    legacysupport.newest_darwin_requires_legacy 10
+
+    depends_lib-append \
+                    port:${name} \
+                    port:xorg-libxcb
+
+    configure.args-replace \
+                    -Denable-x11=false -Denable-x11=true
+
+    post-destroot {
+        # Upstream wants packagers to package libxkbcommon-x11 separately
+        # from libxkbcommon (see PACKAGING) yet refuses to provide a way
+        # to do so, so we have to delete everything libxkbcommon already
+        # provides manually.
+        # https://github.com/xkbcommon/libxkbcommon/issues/75
+        fs-traverse item ${destroot} {
+            if {![file isdirectory ${item}] && ![string match *x11* [file tail ${item}]]} {
+                delete ${item}
+            }
+        }
+    }
+}
+
+if {${subport} ne ${name}} {
+    livecheck.type  none
+}

--- a/devel/libxkbcommon/Portfile
+++ b/devel/libxkbcommon/Portfile
@@ -65,6 +65,14 @@ subport ${name}-x11 {
                     port:${name} \
                     port:xorg-libxcb
 
+    # The tests enabled by -Denable-x11=true require <spawn.h>, which tiger
+    # does not have.
+    platform darwin 8 {
+        patchfiles-append \
+                test_x11comp.c_tiger.diff \
+                test_xvfb-wrapper.c_tiger.diff
+    }
+
     configure.args-replace \
                     -Denable-x11=false -Denable-x11=true
 

--- a/devel/libxkbcommon/files/test_x11comp.c_tiger.diff
+++ b/devel/libxkbcommon/files/test_x11comp.c_tiger.diff
@@ -1,0 +1,36 @@
+--- test/x11comp.c.orig	2026-08-17 15:58:17.000000000 -0600
++++ test/x11comp.c	2026-08-17 16:28:16.000000000 -0600
+@@ -24,7 +24,14 @@
+ #include "config.h"
+ 
+ #include <stdio.h>
+-#include <spawn.h>
++#if defined(__APPLE__)
++    #include "AvailabilityMacros.h"
++    #if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
++        #include <spawn.h>
++    #endif
++#else
++    #include <spawn.h>
++#endif
+ #include <unistd.h>
+ #include <assert.h>
+ #include <signal.h>
+@@ -37,6 +44,9 @@
+ 
+ X11_TEST(test_basic)
+ {
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++    return 0;
++#else
+     struct xkb_keymap *keymap;
+     xcb_connection_t *conn;
+     int32_t device_id;
+@@ -114,6 +124,7 @@
+     xcb_disconnect(conn);
+ err_conn:
+     return ret;
++#endif
+ }
+ 
+ int main(void) {

--- a/devel/libxkbcommon/files/test_xvfb-wrapper.c_tiger.diff
+++ b/devel/libxkbcommon/files/test_xvfb-wrapper.c_tiger.diff
@@ -1,0 +1,36 @@
+--- test/xvfb-wrapper.c.orig	2026-08-17 16:14:33.000000000 -0600
++++ test/xvfb-wrapper.c	2026-08-17 16:29:02.000000000 -0600
+@@ -25,7 +25,14 @@
+ #include "config.h"
+ 
+ #include <stdio.h>
+-#include <spawn.h>
++#if defined(__APPLE__)
++    #include "AvailabilityMacros.h"
++    #if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
++        #include <spawn.h>
++    #endif
++#else
++    #include <spawn.h>
++#endif
+ #include <assert.h>
+ #include <signal.h>
+ #include <sys/types.h>
+@@ -46,6 +53,9 @@
+ int
+ xvfb_wrapper(int (*test_func)(char* display))
+ {
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++    return 0;
++#else
+     int ret = 0;
+     FILE * display_fd;
+     char display_fd_string[32];
+@@ -134,6 +144,7 @@
+     fclose(display_fd);
+ err_display_fd:
+     return ret;
++#endif
+ }
+ 
+ /* All X11_TEST functions are in the test_func_sec ELF section.


### PR DESCRIPTION
The test programs require spawn.h, which 10.4 sdk does not provide. So skip the tests. Surprisingly no there is not a way to disable the tests via build system config.