### PR TITLE
fontconfig: use same xz tarball like MacPorts so that fetching from mirrors work

### DIFF
--- a/graphics/fontconfig/Portfile
+++ b/graphics/fontconfig/Portfile
@@ -18,9 +18,14 @@ long_description            Fontconfig is a library for configuring \
                             and customizing font access.
 
 homepage                    https://www.freedesktop.org/wiki/Software/fontconfig
-checksums                   rmd160  0a84e9647538eb34f40fba33bb058426ec2a4256 \
-                            sha256  8d28f79d2017cbe1fbb7da84b2502c86421b4f45860234d2f4ab5b35564c8d01 \
-                            size    544066
+# the tarball from GitLab has no configure script, this appears to be the "release"
+# but the gitlab PG does not support this. See: https://trac.macports.org/ticket/71113
+master_sites                https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/${version}
+use_xz                      yes
+
+checksums                   rmd160  5a05f7ffd0d4794831e720f37cefc3ad11bebbfd \
+                            sha256  4f7b554a38cdf78c033f666c8871f3749e14a094f65a07f630c91ed0b43d35e3 \
+                            size    1172016
 
 set python_version          3.14
 


### PR DESCRIPTION
Please check that I didn't break gitlab pull. But I got the tarball directly from gitlab (they only offer xz now starting this release) so I had to change that. Also, no http distfile mirror has been refreshed yet to include the new xz, but it's working from [http://tigerports.com/macports/distfiles](http://tigerports.com/macports/distfiles) fine