### PR TITLE
libsdl2-cocoa: enable audio on tiger

### DIFF
--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -127,10 +127,19 @@ platform darwin 10 {
                     +oldapi
 }
 
-# FIXME: look into fixing CoreAudio module for Tiger.
+# Coreaudio is completely different on 10.5 and newer. Use pulseaudio instead.
 if {${os.platform} eq "darwin" && ${os.major} < 9} {
+    depends_build-append port:pulseaudio
+
+    configure.args-replace \
+                    --disable-pulseaudio \
+                    --enable-pulseaudio
+
+    # Normally on Mac OS X configure forces coreaudio, and never even checks 
+    # for pulseaudio. This makes it only check for coreaudio.
+    patchfiles-append    configure_tiger.diff
+
     configure.args-append \
-                    --disable-audio \
                     --disable-haptic \
                     --disable-hidapi \
                     --disable-hidapi-joystick \

--- a/devel/libsdl2-cocoa/Portfile
+++ b/devel/libsdl2-cocoa/Portfile
@@ -128,15 +128,17 @@ platform darwin 10 {
 }
 
 # Coreaudio is completely different on 10.5 and newer. Use pulseaudio instead.
-if {${os.platform} eq "darwin" && ${os.major} < 9} {
-    depends_build-append port:pulseaudio
+platform darwin 8 {
+    # Revision bump for audio support on tiger.
+    incr revision
+    depends_lib-append port:pulseaudio
 
     configure.args-replace \
                     --disable-pulseaudio \
                     --enable-pulseaudio
 
     # Normally on Mac OS X configure forces coreaudio, and never even checks 
-    # for pulseaudio. This makes it only check for coreaudio.
+    # for pulseaudio. This patch makes it only check for pulseaudio.
     patchfiles-append    configure_tiger.diff
 
     configure.args-append \

--- a/devel/libsdl2-cocoa/files/configure_tiger.diff
+++ b/devel/libsdl2-cocoa/files/configure_tiger.diff
@@ -1,0 +1,29 @@
+--- configure.orig	2026-08-17 23:30:13.000000000 -0600
++++ configure	2026-08-17 23:34:45.000000000 -0600
+@@ -29304,11 +29304,7 @@
+         fi
+         # Set up files for the audio library
+         if test x$enable_audio = xyes; then
+-
+-printf "%s\n" "#define SDL_AUDIO_DRIVER_COREAUDIO 1" >>confdefs.h
+-
+-            SOURCES="$SOURCES $srcdir/src/audio/coreaudio/*.m"
+-            SUMMARY_audio="${SUMMARY_audio} coreaudio"
++            CheckPulseAudio
+             have_audio=yes
+         fi
+         # Set up files for the joystick library
+@@ -29450,12 +29446,7 @@
+         fi
+         # Set up files for the audio library
+         if test x$enable_audio = xyes; then
+-
+-printf "%s\n" "#define SDL_AUDIO_DRIVER_COREAUDIO 1" >>confdefs.h
+-
+-            SOURCES="$SOURCES $srcdir/src/audio/coreaudio/*.m"
+-            EXTRA_LDFLAGS="$EXTRA_LDFLAGS -Wl,-framework,CoreAudio -Wl,-framework,AudioToolbox"
+-            SUMMARY_audio="${SUMMARY_audio} coreaudio"
++            CheckPulseAudio
+             have_audio=yes
+         fi
+         # Set up files for the joystick library


### PR DESCRIPTION
Tested some sample audio programs playing wavs and whatnot and no problems. Will be testing things like video players soon.

Must sudo port load everything for dbus and pulseaudio that it asks for after install to get this to work. Note: dbus has a system wide user agent that wont work on ppc-ports base for tiger specifically. (there is a workaround i did for tigerports-base and it's working fine there). I'll try to submit the workaround into ppcports-base tiger_upd branch if there is interest.
