### PR TITLE
dbus: fix linking on tiger

### DIFF
--- a/devel/dbus/Portfile
+++ b/devel/dbus/Portfile
@@ -109,6 +109,18 @@ pre-destroot {
 }
 
 post-destroot {
+    # On Tiger dbus-daemon-launch-helper is trying to load the dylib from the
+    # wrong folder because the dylib it's linked with has @loader_path but the
+    # dylib is not in the same folder as dbus-daemon-launch-helper. It is
+    # installed to the correct place (verified on supported mac os with
+    # official macports) so for now just fix it with install_name_tool.
+    if {$macosx_deployment_target eq "10.4"} {
+        system "install_name_tool -change \
+            '@loader_path/libdbus-1.3.dylib' \
+            '@loader_path/../lib/libdbus-1.3.dylib' \
+            ${destroot}${prefix}/libexec/dbus-daemon-launch-helper"
+    }
+
     # Simplify startup script over startupitem.install.
     # See #15081
     xinstall -d -m 0755 ${destroot}${prefix}/etc/LaunchDaemons/${daemon_uniquename}

--- a/devel/dbus/Portfile
+++ b/devel/dbus/Portfile
@@ -8,6 +8,11 @@ name            dbus
 version         1.16.2
 revision        0
 
+# Fixed dbus linking error on tiger.
+platform darwin 8 {
+    revision        1
+}
+
 maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
 categories      devel
 license         {AFL-2.1 GPL-2+}
@@ -114,7 +119,7 @@ post-destroot {
     # dylib is not in the same folder as dbus-daemon-launch-helper. It is
     # installed to the correct place (verified on supported mac os with
     # official macports) so for now just fix it with install_name_tool.
-    if {$macosx_deployment_target eq "10.4"} {
+    platform darwin 8 {
         system "install_name_tool -change \
             '@loader_path/libdbus-1.3.dylib' \
             '@loader_path/../lib/libdbus-1.3.dylib' \


### PR DESCRIPTION
I _really dont like this _hack__, but this is something that was needed to get libsdl2-cocoa working with pulseaudio as it's a pulseaudio dependency. I wanted to wait until I figured out a better fix but now that libsdl2-cocoa+pulseaudio is working on tiger I want to at least post this so that the entire dependency chain fixes can be known.  Perhaps @ForestExpertise could take a look too. This is the last fix I hadn't yet submitted for the pulse audio tiger dep chain.