### PR TITLE
wayland: fix OSX 10.9 build with default MacPorts

### DIFF
--- a/wayland/wayland/Portfile
+++ b/wayland/wayland/Portfile
@@ -79,12 +79,20 @@ if {${subport} eq "${name}"} {
     # stdatomic.h
     compiler.c_standard 2011
 
+    # because Apple Clang 6 on OS X 10.9 appears to lack stdatomic.h
+    compiler.blacklist-append {clang < 602}
+
     configure.args-append \
                     -Ddocumentation=false \
                     -Ddtd_validation=true \
                     -Dlibraries=true \
                     -Dscanner=true \
                     -Dtests=true
+
+    if [string match *clang* ${configure.compiler}] {
+        configure.args-append \
+                    -Dc_std=c11
+    }
 
     variant docs description "Install docs" {
         configure.args-replace \


### PR DESCRIPTION
* pins c verison with meson to c11 for stdatomic.h
* blacklist apple clang 6 which lacks stdatomic.h afaik

alternative approach is to disable tests, but yeah, not a good idea.
test passes for me... except for two. display and compositor-introspection. irrelevant for this patch because stdatomic.h not found was in compositor test.