### PR TITLE
aqua/aqualink: add draft Portfile

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -1,11 +1,13 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 name                aqualink
-version             0.2
+github.setup        watermark-hd ppc-mac-modernization 0.3 v
+revision            0
 categories          aqua net
-platforms           darwin
 license             unknown
 maintainers         nomaintainer
 
@@ -20,56 +22,27 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a \
                     WebDAV share that a modern Mac or Windows machine can mount.
 
-homepage            https://github.com/watermark-hd/ppc-mac-modernization
+checksums           rmd160  a1ac242269c248469d521b473116d490dec22ba8 \
+                    sha256  7e136d953b114fbad3f0e96cad6f5d2181718edb42fd81c8f69fa81e3636f470 \
+                    size    76595
+github.tarball_from archive
 
-# Two upstream sources are needed here: AquaLink itself, and libsmb2 (the
-# SMB2/3 client library it links against statically, no other dependencies).
-# libsmb2 isn't packaged as its own port in this tree yet, so for now it's
-# vendored and built inline as part of this port. Once something else in
-# the tree needs libsmb2 too, it'd make sense to split it into its own
-# port and switch this to depends_lib on that instead.
+worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink
 
-distfiles           v${version}.tar.gz:aqualink \
-                    v6.0.0.tar.gz:libsmb2
+depends_lib-append  port:libsmb2
 
-master_sites        aqualink:https://github.com/watermark-hd/ppc-mac-modernization/archive/refs/tags/ \
-                    libsmb2:https://github.com/sahlberg/libsmb2/archive/refs/tags/
+compiler.c_standard 1999
 
-checksums           v${version}.tar.gz \
-                        rmd160  497a9d7a3f24f014d9a43e83762d194b1e1f6818 \
-                        sha256  ffc332ad4b29ebf9e5e7faede02a5077daced9c140b214726f2c613cbdb6c3df \
-                        size    72515 \
-                    v6.0.0.tar.gz \
-                        rmd160  92986625eb6eea5b7fc9727ea872a4786c6246e5 \
-                        sha256  c65a7a2b7a6e967a4fd5b6168fca4f1f7d0362a3510767700609c770e3ead1e8 \
-                        size    256687
-
-worksrcdir          ppc-mac-modernization-${version}
-
-use_configure       no
-
-depends_build-append \
-                    port:autoconf \
-                    port:automake \
-                    port:libtool
-
-libsmb2.dir         ${workpath}/libsmb2-6.0.0
-app.dir             ${worksrcpath}/smb3/AquaLink
-
-build {
-    # libsmb2 first, as a static library; AquaLink's Makefile links against
-    # the .a directly and expects an autotools-style build layout
-    # (include/ + lib/.libs/libsmb2.a).
-    system -W ${libsmb2.dir} "./bootstrap"
-    system -W ${libsmb2.dir} "./configure --disable-shared"
-    system -W ${libsmb2.dir} "make"
-
-    system -W ${app.dir} "make LIBSMB2_DIR=${libsmb2.dir}"
-}
+# The upstream Makefile now resolves the libsmb2 library on its own from
+# LIBSMB2_DIR alone (checks for an installed dylib, then an installed
+# static .a, then falls back to an uninstalled build-tree layout), so no
+# Makefile patch is needed here -- this alone is enough to point it at
+# this port's libsmb2 install.
+build.args          LIBSMB2_DIR=${prefix}
 
 destroot {
     xinstall -d ${destroot}${applications_dir}
-    copy ${app.dir}/AquaLink.app ${destroot}${applications_dir}
+    copy ${worksrcpath}/AquaLink.app ${destroot}${applications_dir}
 }
 
 livecheck.type      regex

--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -1,0 +1,77 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                aqualink
+version             0.2
+categories          aqua net
+platforms           darwin
+license             unknown
+maintainers         nomaintainer
+
+description         SMB2/3 client and WebDAV NAS bridge for PowerPC Mac (Tiger/Leopard)
+
+long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect to \
+                    modern SMB2/3 NAS shares, which the OS's built-in SMB1-only \
+                    Samba stack cannot speak. It provides a Transmit/Cyberduck-style \
+                    file browser for drag-and-drop transfers, and a local WebDAV \
+                    bridge that lets the same share be mounted as a normal Finder \
+                    volume via mount_webdav, without any kernel extension. It also \
+                    includes the reverse: exposing a folder on the old Mac as a \
+                    WebDAV share that a modern Mac or Windows machine can mount.
+
+homepage            https://github.com/watermark-hd/ppc-mac-modernization
+
+# Two upstream sources are needed here: AquaLink itself, and libsmb2 (the
+# SMB2/3 client library it links against statically, no other dependencies).
+# libsmb2 isn't packaged as its own port in this tree yet, so for now it's
+# vendored and built inline as part of this port. Once something else in
+# the tree needs libsmb2 too, it'd make sense to split it into its own
+# port and switch this to depends_lib on that instead.
+
+distfiles           v${version}.tar.gz:aqualink \
+                    v6.0.0.tar.gz:libsmb2
+
+master_sites        aqualink:https://github.com/watermark-hd/ppc-mac-modernization/archive/refs/tags/ \
+                    libsmb2:https://github.com/sahlberg/libsmb2/archive/refs/tags/
+
+checksums           v${version}.tar.gz \
+                        rmd160  497a9d7a3f24f014d9a43e83762d194b1e1f6818 \
+                        sha256  ffc332ad4b29ebf9e5e7faede02a5077daced9c140b214726f2c613cbdb6c3df \
+                        size    72515 \
+                    v6.0.0.tar.gz \
+                        rmd160  92986625eb6eea5b7fc9727ea872a4786c6246e5 \
+                        sha256  c65a7a2b7a6e967a4fd5b6168fca4f1f7d0362a3510767700609c770e3ead1e8 \
+                        size    256687
+
+worksrcdir          ppc-mac-modernization-${version}
+
+use_configure       no
+
+depends_build-append \
+                    port:autoconf \
+                    port:automake \
+                    port:libtool
+
+libsmb2.dir         ${workpath}/libsmb2-6.0.0
+app.dir             ${worksrcpath}/smb3/AquaLink
+
+build {
+    # libsmb2 first, as a static library; AquaLink's Makefile links against
+    # the .a directly and expects an autotools-style build layout
+    # (include/ + lib/.libs/libsmb2.a).
+    system -W ${libsmb2.dir} "./bootstrap"
+    system -W ${libsmb2.dir} "./configure --disable-shared"
+    system -W ${libsmb2.dir} "make"
+
+    system -W ${app.dir} "make LIBSMB2_DIR=${libsmb2.dir}"
+}
+
+destroot {
+    xinstall -d ${destroot}${applications_dir}
+    copy ${app.dir}/AquaLink.app ${destroot}${applications_dir}
+}
+
+livecheck.type      regex
+livecheck.url       https://github.com/watermark-hd/ppc-mac-modernization/tags
+livecheck.regex     {v(\d+(?:\.\d+)*)}


### PR DESCRIPTION
Draft Portfile for AquaLink (SMB2/3 client + WebDAV NAS bridge for Tiger/Leopard PowerPC Macs), per the suggestion in the MacRumors thread: https://forums.macrumors.com/threads/aqualink-smb2-3-client-for-powerpc-tiger-leopard-mounts-modern-nas-shares-in-finder.2487262/

Upstream source: https://github.com/watermark-hd/ppc-mac-modernization (tag v0.2)

## Known gaps / things I'd appreciate a look at

- This vendors and builds libsmb2 6.0.0 inline (bootstrap/configure/make) rather than depending on a proper `libsmb2` port, since one doesn't exist in this tree yet. Happy to split it out into its own port if that's preferred.
- Build/destroot logic is written to match the mkconsole Portfile's general shape, but I don't have a local MacPorts install to `port lint` or test-build this against, so structural mistakes are likely.
- `license` is set to `unknown` — the upstream repo doesn't declare one explicitly yet, will fix upstream and update this.
- `maintainers` left as `nomaintainer` for now.

This is intentionally a rough first pass, not a finished PR — flagging as draft so it's clear it needs a look before merging.