### PR TITLE
libepoxy: disable egl related tests on Tiger to fix build

### DIFF
--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -32,6 +32,10 @@ patchfiles          patch-meson.diff \
 platform darwin 8 {
     configure.cflags-append -DCGLReleasePixelFormat=CGLDestroyPixelFormat
     configure.cflags-append -DCGLReleaseContext=CGLDestroyContext
+    #one of the egl tests fails, but this is trivial to disable.
+    if {[variant_isset egl]} {
+        configure.args-append -Dtests=false
+    }
 }
 
 set py_ver          3.14


### PR DESCRIPTION
libepoxy on Tiger appears to work fine, but one of the tests won't compile and it seems easier to just disable the tests when building that variant. @alex_free you are welcome to pitch a better solution if desired.