### PR TITLE
doxygen: use fallback on Tiger, fix for gcc16

### DIFF
--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -105,19 +105,19 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
                         path:bin/git:git
     configure.args-append \
                         -DGIT_EXECUTABLE=${prefix}/bin/git
+}
 
-    if {${os.major} < 9} {
-        #use fallback on Tiger since current version doesn't build and doxygen is usually just a build time dependency
-        version                 1.17.0
-        revision                2
-        epoch                   2
-        checksums               rmd160  e9546ecf9acb30d8bf905ce877e07ecd7f4a3f5d \
-                                sha256  fa4c3dd78785abc11ccc992bc9c01e7a8c3120fe14b8a8dfd7cefa7014530814 \
-                                size    9350308
+if {${os.platform} eq "darwin" && ${os.major} < 9} {
+    #use fallback on Tiger since current version doesn't build and doxygen is usually just a build time dependency
+    version                 1.17.0
+    revision                2
+    epoch                   2
+    checksums               rmd160  e9546ecf9acb30d8bf905ce877e07ecd7f4a3f5d \
+                            sha256  fa4c3dd78785abc11ccc992bc9c01e7a8c3120fe14b8a8dfd7cefa7014530814 \
+                            size    9350308
 
-        if {[string match "macports-gcc-*" ${configure.compiler}]} {
-            configure.cflags-append "-Wno-error=incompatible-pointer-types"
-        }
+    if {[string match "macports-gcc-*" ${configure.compiler}]} {
+        configure.cflags-append "-Wno-error=incompatible-pointer-types"
     }
 }
 

--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -105,6 +105,20 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
                         path:bin/git:git
     configure.args-append \
                         -DGIT_EXECUTABLE=${prefix}/bin/git
+
+    if {${os.major} < 9} {
+        #use fallback on Tiger since current version doesn't build and doxygen is usually just a build time dependency
+        version                 1.17.0
+        revision                2
+        epoch                   2
+        checksums               rmd160  e9546ecf9acb30d8bf905ce877e07ecd7f4a3f5d \
+                                sha256  fa4c3dd78785abc11ccc992bc9c01e7a8c3120fe14b8a8dfd7cefa7014530814 \
+                                size    9350308
+
+        if {[string match "macports-gcc-*" ${configure.compiler}]} {
+            configure.cflags-append "-Wno-error=incompatible-pointer-types"
+        }
+    }
 }
 
 # cmake PortGroup sets arch flags


### PR DESCRIPTION
Since doxygen is almost always a build time dependency, it is an ideal candidate for a fallback. Since the current version doesn't build, this seems like the path of least resistance. @alex-free if you would prefer to fix the current build, I have no objection.