### PR TITLE
devel/libsmb2: patch SessionId endian bug in SMB3 encryption

### DIFF
--- a/devel/libsmb2/Portfile
+++ b/devel/libsmb2/Portfile
@@ -16,8 +16,13 @@ checksums           rmd160  a90c5961f500f10d75eb96ff541b4aa8e7c2cff8 \
                     size    259518
 github.tarball_from archive
 
-# https://github.com/sahlberg/libsmb2/issues/476
-patchfiles-append   patch-fix-kerberos.diff
+# patch-fix-kerberos.diff: https://github.com/sahlberg/libsmb2/issues/476
+# patch-fix-sessionid-endian.diff: SessionId in the SMB3 encryption transform
+# header was not byte-swapped for the wire, so smb2_set_seal() fails on
+# big-endian hosts (PPC). Reported upstream:
+# https://github.com/sahlberg/libsmb2/issues/477
+patchfiles-append   patch-fix-kerberos.diff \
+                    patch-fix-sessionid-endian.diff
 
 use_autoreconf      yes
 autoreconf.args     -fiv

--- a/devel/libsmb2/files/patch-fix-sessionid-endian.diff
+++ b/devel/libsmb2/files/patch-fix-sessionid-endian.diff
@@ -1,14 +1,11 @@
 --- lib/smb3-seal.c	2024-12-23 11:38:55.000000000 +0800
-+++ lib/smb3-seal.c	2026-08-28 08:43:23.000000000 +0800
-@@ -103,7 +103,10 @@
++++ lib/smb3-seal.c	2026-08-28 09:15:00.000000000 +0800
+@@ -103,7 +103,7 @@
          memcpy(&pdu->crypt[36], &u32, 4);
          u16 = htole16(SMB_ENCRYPTION_AES128_CCM);
          memcpy(&pdu->crypt[42], &u16, 2);
 -        memcpy(&pdu->crypt[44], &smb2->session_id, 8);
-+        {
-+                uint64_t sid_le = htole64(smb2->session_id);
-+                memcpy(&pdu->crypt[44], &sid_le, 8);
-+        }
++        *(uint64_t *)(void *)&pdu->crypt[44] = htole64(smb2->session_id);
 
          spl = 52;  /* transform header */
          for (tmp_pdu = pdu; tmp_pdu; tmp_pdu = tmp_pdu->next_compound) {

--- a/devel/libsmb2/files/patch-fix-sessionid-endian.diff
+++ b/devel/libsmb2/files/patch-fix-sessionid-endian.diff
@@ -1,0 +1,14 @@
+--- lib/smb3-seal.c	2024-12-23 11:38:55.000000000 +0800
++++ lib/smb3-seal.c	2026-08-28 08:43:23.000000000 +0800
+@@ -103,7 +103,10 @@
+         memcpy(&pdu->crypt[36], &u32, 4);
+         u16 = htole16(SMB_ENCRYPTION_AES128_CCM);
+         memcpy(&pdu->crypt[42], &u16, 2);
+-        memcpy(&pdu->crypt[44], &smb2->session_id, 8);
++        {
++                uint64_t sid_le = htole64(smb2->session_id);
++                memcpy(&pdu->crypt[44], &sid_le, 8);
++        }
+
+         spl = 52;  /* transform header */
+         for (tmp_pdu = pdu; tmp_pdu; tmp_pdu = tmp_pdu->next_compound) {


### PR DESCRIPTION
Follow-up to the discussion on #232.

`lib/smb3-seal.c` writes the SMB2_TRANSFORM_HEADER's `SessionId` field with a raw `memcpy` of the host-order value, unlike the other multi-byte fields in the same header (`OriginalMessageSize`, `EncryptionAlgorithm`), which are explicitly converted with `htole32`/`htole16` first. This is a no-op bug on little-endian hosts (x86/ARM), since host order already equals wire order for a raw copy -- but on big-endian (PPC) it puts a byte-reversed SessionId in every encrypted PDU, which any server correctly rejects.

Confirmed on real PPC hardware (Tiger iBook G4): with `smb2_set_seal(ctx, 1)`, NEGOTIATE and SESSION_SETUP succeed, then the connection is dropped right after the first TRANSFORM_HEADER-wrapped PDU. Packet capture shows this happening identically against two unrelated server implementations -- macOS's and Windows 11's standard SMB3 sharing -- which is why this looks like the wire format rather than two servers sharing a bug.

Reported upstream with the same fix: sahlberg/libsmb2#477

`aqualink` (`aqua/aqualink`, #232) is the only consumer of this port right now and needs this for its "require SMB3 encryption" option to actually work. Tested locally by patching a real libsmb2 v6.0.0 checkout with the same diff and confirming the connection succeeds against both macOS and Windows 11.