### PR TITLE
aqua/aqualink: bump to v0.4

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.3 v
+github.setup        watermark-hd ppc-mac-modernization 0.4 v
 revision            0
 categories          aqua net
 license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a \
                     WebDAV share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  a1ac242269c248469d521b473116d490dec22ba8 \
-                    sha256  7e136d953b114fbad3f0e96cad6f5d2181718edb42fd81c8f69fa81e3636f470 \
-                    size    76595
+checksums           rmd160  961f56de66d7a49259f59fdd68890a11af8b1841 \
+                    sha256  d0151f61f6ed91ee01e652824445754824b8d30b2a2bc1f5e890cf1faefd868c \
+                    size    79087
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.3 to 0.4.

v0.4 adds an option to require SMB3 encryption end-to-end (checkbox on the
connect screen), and fixes a URL-parsing bug where usernames containing "@"
(e.g. Microsoft account emails like `user@hotmail.com`) broke the SMB URL.

devel/libsmb2 already carries the SessionId endian fix (commit 8b844c5) that
makes the encryption option actually work on big-endian hosts, so this is
what makes that feature usable through the port.

Suggested by @barracuda156 on the AquaLink v0.3 issue thread.