### PR TITLE
aqua/aqualink: bump to v0.5

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.4 v
+github.setup        watermark-hd ppc-mac-modernization 0.5 v
 revision            0
 categories          aqua net
 license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a \
                     WebDAV share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  961f56de66d7a49259f59fdd68890a11af8b1841 \
-                    sha256  d0151f61f6ed91ee01e652824445754824b8d30b2a2bc1f5e890cf1faefd868c \
-                    size    79087
+checksums           rmd160  e9c89abceed1176f08478842c90772c6f0fb018c \
+                    sha256  df5df741db2b1aa7a1d0c75e6e41497a7fd78d44779269131ed34d69edab0ff4 \
+                    size    82026
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.4 to 0.5.

Fixes a connection failure specific to this port: devel/libsmb2 builds
with Kerberos/GSSAPI support by default, and libsmb2 itself defaults
to trying Kerberos before falling back to NTLM. Against a home NAS
with no krb5 realm/KDC, `gss_acquire_cred` fails and SPNEGO never
falls back to NTLM, so the connection is refused outright:

```
Connection failed: gss_acquire_cred: (Ein ungültiger Name wurde
übergeben., SPNEGO kann keine Mechanismen zum Aushandeln finden.)
```

AquaLink now explicitly requests NTLM authentication
(`smb2_set_authentication(ctx, SMB2_SEC_NTLMSSP)`), since it targets
home NAS / workgroup SMB shares rather than AD domains. Confirmed
building on real Tiger hardware; full writeup in `smb3/README.md`.