### PR TITLE
mesa: fix i386

### DIFF
--- a/x11/mesa/Portfile
+++ b/x11/mesa/Portfile
@@ -74,6 +74,17 @@ patchfiles-append       patch-build-with-LLVM-7-${version}.diff
 # https://gitlab.freedesktop.org/mesa/mesa/-/work_items/16103
 patchfiles-append       patch-no-MAP_JIT.diff
 
+# Expects as to understand _xgetbv:
+# blake3_dispatch.c:55:no such instruction: `xgetbv'
+# Expects as to understand clflushopt gcc builtin's instructions:
+# cache_ops_x86_clflushopt.c {standard input}:105:no such instruction: 
+# `clflushopt (%eax)'
+if {${configure.build_arch} eq "i386"} {
+    patchfiles-append \
+        src_util_blake3_blake3_dispatch.c_i386.diff \
+        meson.build_i386.diff
+}
+
 # Incorrect usage of macros in 26.2.0:
 patchfiles-append       patch-fix-silly-macros-bug.diff
 

--- a/x11/mesa/files/meson.build_i386.diff
+++ b/x11/mesa/files/meson.build_i386.diff
@@ -1,0 +1,20 @@
+--- meson.build.orig	2026-08-17 00:27:08.000000000 -0600
++++ meson.build	2026-08-17 00:28:18.000000000 -0600
+@@ -1456,15 +1456,8 @@
+   endif
+ endif
+ 
+-# Detect __builtin_ia32_clflushopt support
+-if cc.has_function('__builtin_ia32_clflushopt', args : '-mclflushopt')
+-  pre_args += '-DHAVE___BUILTIN_IA32_CLFLUSHOPT'
+-  clflushopt_args = ['-mclflushopt']
+-  with_clflushopt = true
+-else
+-  clflushopt_args = []
+-  with_clflushopt = false
+-endif
++clflushopt_args = []
++with_clflushopt = false
+ 
+ # Check for GCC style atomics
+ dep_atomic = null_dep

--- a/x11/mesa/files/src_util_blake3_blake3_dispatch.c_i386.diff
+++ b/x11/mesa/files/src_util_blake3_blake3_dispatch.c_i386.diff
@@ -1,0 +1,21 @@
+--- src/util/blake3/blake3_dispatch.c.orig	2026-08-16 22:43:19.000000000 -0600
++++ src/util/blake3/blake3_dispatch.c	2026-08-16 22:43:38.000000000 -0600
+@@ -51,10 +51,18 @@
+ #if defined(_MSC_VER)
+   return _xgetbv(0);
+ #else
++#if defined(__APPLE__) && defined(__i386__)
++// This is expecting _xgetbv in some form to exist so that features can be
++// checked for, but on older Intel CPUs it does not, so return feature can
++// not be used by returning zero always.
++// https://stackoverflow.com/questions/72522885/are-the-xgetbv-and-cpuid-checks-sufficient-to-guarantee-avx2-support
++return 0;
++#else
+   uint32_t eax = 0, edx = 0;
+   __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
+   return ((uint64_t)edx << 32) | eax;
+ #endif
++#endif
+ }
+ 
+ static void cpuid(uint32_t out[4], uint32_t id) {


### PR DESCRIPTION
This is the same as https://github.com/macos-powerpc/powerpc-ports/pull/221 but updated for new mesa version, as the original pull request got stale. Builds on Tiger i386, I do have to manually remove the problematic patch that @ForestExpertise 's pull request removes. However this pull request specifically doesn't remove that problematic patch in hopes that it will not conflict with https://github.com/macos-powerpc/powerpc-ports/pull/233 . If It does I can redo it.