### PR TITLE
libepoxy: don't set default variant to egl on tiger

### DIFF
--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -90,7 +90,8 @@ variant egl conflicts angle quartz description "Enable EGL via Mesa" {
     depends_lib-append      port:mesa
 }
 
-if {![variant_isset angle]} {
+# This variant is only needed for wayland, which isn't available on 10.4 yet.
+if {${os.platform} eq "darwin" && ${os.major} > 8 && ![variant_isset angle]} {
     default_variants-append +egl
 }
 

--- a/graphics/libepoxy/Portfile
+++ b/graphics/libepoxy/Portfile
@@ -91,7 +91,7 @@ variant egl conflicts angle quartz description "Enable EGL via Mesa" {
 }
 
 # This variant is only needed for wayland, which isn't available on 10.4 yet.
-if {${os.platform} eq "darwin" && ${os.major} > 8 && ![variant_isset angle]} {
+if {(${os.platform} ne "darwin" || ${os.major} > 8) && ![variant_isset angle]} {
     default_variants-append +egl
 }
 


### PR DESCRIPTION
Proposed alternative as suggested in https://github.com/macos-powerpc/powerpc-ports/pull/233#issuecomment-5458664081

If wayland isn't working on 10.5 yet, perhaps increase this to darwin 9?
