### PR TITLE
aqua/aqualink: bump to v0.5.2 (fixes build regressions in v0.5)

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.1 v
 revision            0
 categories          aqua net
 license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a \
                     WebDAV share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  e9c89abceed1176f08478842c90772c6f0fb018c \
-                    sha256  df5df741db2b1aa7a1d0c75e6e41497a7fd78d44779269131ed34d69edab0ff4 \
-                    size    82026
+checksums           rmd160  1c7c28eda509eb91772351c5e31f152fbce0e176 \
+                    sha256  051f54ca1dbec25ea522bb49e6a8e4e46088e80d9be0254104945188ea67ade5 \
+                    size    82999
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Sorry, this now fixes two issues found in quick succession after the
v0.5 bump (#238), both same-day.

**1. v0.5's Makefile regression** (originally what this PR fixed): an
`-isysroot /Developer/SDKs/MacOSX10.4u.sdk` fallback used the wrong
condition ("use it if it exists on disk" instead of "only if the
system's own headers are missing"), breaking builds on Leopard/Snow
Leopard where live headers are intact.

**2. v0.5.1 still failed to build** against this port specifically:
`smb2_set_authentication()` is declared in libsmb2-6.2's public
header, but the `SMB2_SEC_NTLMSSP` enum value it takes only exists in
libsmb2's *private* header in every tagged release so far — it was
only moved to a public header on master (commit fbe9674), not yet in
any release. My own hardware testing was done against a libsmb2
master build, so I didn't catch this until a user hit it against the
tagged release this port uses.

v0.5.2 adds a `#ifndef`-guarded compat definition (same integer values
libsmb2 has used since 2019) so it builds against tagged releases
too, while still preferring the real definition if one is ever
present. Full writeup in `smb3/README.md`.