### PR TITLE
vvenc: fix i386 build, disable avx and sse4.2

### DIFF
--- a/multimedia/vvenc/Portfile
+++ b/multimedia/vvenc/Portfile
@@ -33,14 +33,19 @@ configure.args-append \
                     -DVVENC_USE_ADDRESS_SANITIZER=OFF
 
 platform i386 {
-    configure.args-delete \
-                    -DVVENC_ENABLE_X86_SIMD=OFF
+    # This enables SSE4.2 (not availble on oldest intel CPUs) and AVX.
+    if {${os.platform} ne "darwin" || (${os.platform} eq "darwin" && ${os.major} > 10)} {        
+        configure.args-delete \
+            -DVVENC_ENABLE_X86_SIMD=OFF
+    }
 }
 
 compiler.cxx_standard   2014
 
 # CommonLib/UnitTools.cpp:1618:11: error: 'memset' used with length equal to number of elements without multiplication by element size [-Werror=memset-elt-size]
+# stl_construct.h:166:7: error: array subscript 'struct mutex[0]' is partly outside array bounds of 'unsigned char[20]' [-Werror=array-bounds=]
 if {[string match *gcc* ${configure.compiler}]} {
     configure.cxxflags-append \
-                    -Wno-error=memset-elt-size
+                    -Wno-error=memset-elt-size \
+                    -Wno-error=array-bounds
 }


### PR DESCRIPTION
I left this on for anything newer then snow leopard, and left it alone if not darwin since it was originally under a platform i386 block. 

The second cxxflag addition seems to be due to gcc16 stricter defaults with warnings so I added that where the other one was.