### PR TITLE
davs2: use macports bash on tiger to fix build

### DIFF
--- a/multimedia/davs2/Portfile
+++ b/multimedia/davs2/Portfile
@@ -27,6 +27,21 @@ configure.args-append \
                     --enable-shared \
                     --system-libdavs2
 
+#./configure: line 1075: CFLAGS+= -DHIGH_BIT_DEPTH=0: command not found
+#./configure: line 1083: CFLAGS+= -DBIT_DEPTH=8: command not found
+# common.h:1201:34: error: 'BIT_DEPTH' was not declared in this scope
+# This is because configure is a bash script, and tiger bash is
+# too old to work with this.
+platform darwin 8 {
+    depends_build-append    port:bash
+
+    post-patch {
+        reinplace "s|#!/bin/bash|#!${prefix}/bin/bash|" \
+            ${worksrcpath}/configure
+    }
+}
+
+
 if {${configure.build_arch} in [list i386 x86_64]} {
     depends_build-append \
                     port:nasm


### PR DESCRIPTION
This is not an autoconf project, but rather a bash script named configure: https://github.com/pkuvcl/davs2/blob/master/build/linux/configure. This calls tiger bash, which is just old enough to not support the variable substitution it needs for setting bit depth. Seemed like cleanest way to fix it is to just use macports bash (which works on tiger just fine)