### PR TITLE
tuntaposx: restore tiger compatibility

### DIFF
--- a/net/tuntaposx/Portfile
+++ b/net/tuntaposx/Portfile
@@ -17,9 +17,22 @@ long_description    Unix-style tun and tap virtual network interfaces for Mac \
 
 homepage            http://tuntaposx.sourceforge.net
 
+if {${os.major} == 8} {
+# Last version to build on tiger as per developer site.
+    version         20080804
+    revision        1
+    checksums       rmd160  b4fa7d3241d4b1ea97f3ca1db73f5669bc3d33ea \
+                    sha256  2cf027fb976dab6221071e9b8a85ef40cb867b065405e35bc823fdd9dba6fcc0 \
+                    size    33796
+
+    patchfiles      src_tap_makefile_tiger.diff \
+                    src_tun_makefile_tiger.diff
+
+    # error: jump to case label../tuntap.cc
+    configure.compiler gcc-4.0
+} elseif {${os.major} == 9} {
 # TODO: verify that a newer version works correctly on 10.6,
 # otherwise change the fallback threshold here.
-if {${os.major} < 10} {
     version         20111101
     revision        1
     checksums       rmd160  d7ec7fbea29d05de3a1532737b74970d9bbcc2ed \
@@ -27,7 +40,8 @@ if {${os.major} < 10} {
                     size    80453
 
     patchfiles      patch-src__tap__Makefile-leopard.diff \
-                    patch-src__tun__Makefile-leopard.diff
+                    patch-src__tun__Makefile-leopard.diff \
+                    patch-leopard.diff
 } else {
     version         20150118
     revision        1
@@ -65,10 +79,6 @@ if {${os.major} >= 18} {
             reinplace "s|@SDKROOT@|${configure.sdkroot}|" ${f}
         }
     }
-}
-
-if {${os.major} <= 9} {
-    patchfiles-append   patch-leopard.diff
 }
 
 use_configure       no

--- a/net/tuntaposx/files/src_tap_makefile_tiger.diff
+++ b/net/tuntaposx/files/src_tap_makefile_tiger.diff
@@ -1,0 +1,23 @@
+--- src/tap/Makefile.orig	2026-09-01 13:09:38.000000000 -0600
++++ src/tap/Makefile	2026-09-01 13:10:29.000000000 -0600
+@@ -23,16 +23,16 @@
+ 	-I/System/Library/Frameworks/Kernel.framework/Headers \
+ 	-I/System/Library/Frameworks/Kernel.framework/Headers/bsd
+ CFLAGS = -static -nostdinc -Wall -msoft-float -mlong-branch -force_cpusubtype_ALL -fno-builtin \
+-	-arch ppc -arch i386 -isysroot /Developer/SDKs/MacOSX10.4u.sdk/ \
++	@ARCHFLAGS@ -isysroot /Developer/SDKs/MacOSX10.4u.sdk/ \
+ 	-DKERNEL -D__APPLE__ -DKERNEL_PRIVATE -DTUNTAP_VERSION=\"$(TUNTAP_VERSION)\" \
+ 	-DTAP_KEXT_VERSION=\"$(TAP_KEXT_VERSION)\"
+ CCFLAGS = $(CFLAGS) -nostdinc++ -fapple-kext -fno-exceptions -fno-rtti
+ LDFLAGS = -static -Wall -nostdlib -r -lcc_kext \
+-	-arch ppc -arch i386 -isysroot /Developer/SDKs/MacOSX10.4u.sdk/
++	@ARCHFLAGS@ -isysroot /Developer/SDKs/MacOSX10.4u.sdk/
+ 
+ 
+-CCP = g++
+-CC = gcc
++CCP = @CXX@
++CC = @CC@
+ 
+ all: $(KMOD_BIN) bundle
+ 

--- a/net/tuntaposx/files/src_tun_makefile_tiger.diff
+++ b/net/tuntaposx/files/src_tun_makefile_tiger.diff
@@ -1,0 +1,22 @@
+--- src/tun/Makefile.orig	2026-09-01 13:07:22.000000000 -0600
++++ src/tun/Makefile	2026-09-01 13:08:46.000000000 -0600
+@@ -23,15 +23,15 @@
+ 	-I/System/Library/Frameworks/Kernel.framework/Headers \
+ 	-I/System/Library/Frameworks/Kernel.framework/Headers/bsd
+ CFLAGS = -static -nostdinc -Wall -msoft-float -mlong-branch -force_cpusubtype_ALL -fno-builtin \
+-	-arch ppc -arch i386 -isysroot /Developer/SDKs/MacOSX10.4u.sdk/ \
++	@ARCHFLAGS@ -isysroot /Developer/SDKs/MacOSX10.4u.sdk/ \
+ 	-DKERNEL -D__APPLE__ -DKERNEL_PRIVATE -DTUNTAP_VERSION=\"$(TUNTAP_VERSION)\" \
+ 	-DTAP_KEXT_VERSION=\"$(TUN_KEXT_VERSION)\"
+ CCFLAGS = $(CFLAGS) -nostdinc++ -fapple-kext -fno-exceptions -fno-rtti
+ LDFLAGS = -static -Wall -nostdlib -r -lcc_kext \
+-	-arch ppc -arch i386 -isysroot /Developer/SDKs/MacOSX10.4u.sdk/
++	@ARCHFLAGS@ -isysroot /Developer/SDKs/MacOSX10.4u.sdk/
+ 
+-CCP = g++
+-CC = gcc
++CCP = @CXX@ 
++CC = @CC@
+ 
+ all: $(KMOD_BIN) bundle
+ 


### PR DESCRIPTION
Uses last version that builds on tiger as per developer changelog: https://tuntaposx.sourceforge.net/download.xhtml.
It seems to be possible to build newer versions from say Leopard or Snow Leopard that target tiger according to that page (at least one version newer), but it doesn't help us _on_ tiger.

Trying to build the 'leopard' version (20111101) or any newer version then the one in the portfile requires apple GCC 4.2, and then is expecting leopard things like 'ld_classic' (which is present on newer Xcode then Tiger can run) when you pass it flags like -mkernel. This makes sense because all newer versions were built using newer Xcode/GCC.

 I'm pretty sure the macports built apple gcc 42 can't build kernel extensions for 10.4, at least not as-is without patching that compiler itself (the ld_classic thing is a leftover from macports 'porting' this from leopard to tiger, although that may not be the only issue as it still may not even work once that's resolved).

So this uses Xcode 2.5 gcc 4.0 (makes sense for kernel extensions). And luckily, the only patches needed were some reinplaces to change it from building universal -arch ppc -arch i386 to whatever is {configure.build_arch} (to match all other OS versions this supports).

Tested with openvpn2 and works great.