### PR TITLE
ghostscript: fix i386 build. fix tiger build with gcc16.

### DIFF
--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -1,0 +1,240 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           muniversal 1.0
+
+name                ghostscript
+version             10.07.1
+revision            0
+
+categories          print
+license             AGPL-3 BSD
+maintainers         nomaintainer
+description         GPL Ghostscript, An interpreter for PostScript and PDF
+long_description    Ghostscript is the well-known PostScript interpreter which \
+                    is available for all common and most esoteric platforms and \
+                    supports many different printers and some displays.
+homepage            https://www.ghostscript.com/
+
+master_sites        https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs[strsed ${version} {g/\.//}]:source \
+                    sourceforge:project/gs-fonts/gs-fonts/6.0%20%28misc%2C%20AFPL%29/:otherfonts \
+                    sourceforge:project/gs-fonts/gs-fonts/8.11%20%28base%2035%2C%20GPL%29/:stdfonts \
+                    https://github.com/adobe-type-tools/mapping-resources-pdf/archive/:misc
+
+# Note: this needs to be manually updated for new upstream commits
+set mappingresources_commit \
+                    2dd5e53fb74a01718b9dfd448a0d1cce6fff2aa5
+
+distname            ghostpdl-${version}
+distfiles           ${distname}.tar.gz:source \
+                    ghostscript-fonts-other-6.0.tar.gz:otherfonts \
+                    ghostscript-fonts-std-8.11.tar.gz:stdfonts \
+                    ${mappingresources_commit}.zip:misc
+
+checksums           ${distname}.tar.gz \
+                    rmd160  f8d8fc6dfff453c97f565a33a335b05db39b474e \
+                    sha256  5c580ed888ce42ce4d76b8afac302e8b507e08d05e52e05b3649e0732559bfe4 \
+                    size    99962592 \
+                    ghostscript-fonts-other-6.0.tar.gz \
+                    rmd160  ab60dbf71e7d91283a106c3df381cadfe173082f \
+                    sha256  4fa051e341167008d37fe34c19d241060cd17b13909932cd7ca7fe759243c2de \
+                    size    796086 \
+                    ghostscript-fonts-std-8.11.tar.gz \
+                    rmd160  10a19a10d0388bc084a7c1d3da845068d7169054 \
+                    sha256  0eb6f356119f2e49b2563210852e17f57f9dcc5755f350a69a46a0d641a0c401 \
+                    size    3752871 \
+                    ${mappingresources_commit}.zip \
+                    rmd160  a65458ab9955421cf3085cf84a6eac299e8c93cb \
+                    sha256  e3971985977cee4b75f6b49f6e43842d3b699c4255d010adb82796073e98fbfe \
+                    size    1601563
+
+extract.only        ${distname}.tar.gz \
+                    ghostscript-fonts-other-6.0.tar.gz \
+                    ghostscript-fonts-std-8.11.tar.gz
+
+post-extract {
+    system -W ${workpath} "unzip '${distpath}/${mappingresources_commit}.zip'"
+
+    foreach d {expat freetype jbig2dec jpeg lcms2mt libpng openjpeg tiff zlib} {
+        move ${worksrcpath}/${d} ${worksrcpath}/${d}_local
+    }
+
+    # https://trac.macports.org/ticket/62832
+    delete ${worksrcpath}/tesseract
+    delete ${worksrcpath}/leptonica
+
+    #move ${workpath}/MappingOther/Adobe-CNS1-ETen-B5 ${workpath}/MappingOther/Adobe-CNS1-ETenms-B5
+    copy -force {*}[glob ${workpath}/mapping-resources-pdf-${mappingresources_commit}/pdf2unicode/*] ${worksrcpath}/Resource/CMap
+    copy -force {*}[glob ${workpath}/mapping-resources-pdf-${mappingresources_commit}/pdf2other/*]    ${worksrcpath}/Resource/CMap
+}
+
+patchfiles-append   patch-base_unixinst.mak.diff
+
+post-patch {
+    reinplace "s|ZLIBDIR=src|ZLIBDIR=${prefix}/include|" \
+                    ${worksrcpath}/configure.ac
+
+    # Ensure that MacPorts perl is used everywhere
+    fs-traverse f ${worksrcpath} {
+        if {[string match *.pl ${f}]} {
+            reinplace -E "s:(/usr/bin/perl|/usr/bin/env perl):${prefix}/bin/perl:g" ${f}
+        }
+    }
+}
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append \
+                    port:fontconfig \
+                    port:freetype \
+                    port:jbig2dec \
+                    port:lcms2 \
+                    port:libiconv \
+                    port:libidn \
+                    path:include/turbojpeg.h:libjpeg-turbo \
+                    port:libpaper \
+                    port:libpng \
+                    port:openjpeg \
+                    port:tiff \
+                    port:zlib
+
+depends_run-append \
+                    port:perl5
+
+compiler.c_standard 1999
+configure.cflags-append -std=gnu99
+
+use_autoreconf      yes
+autoreconf.args     -fv
+configure.checks.implicit_function_declaration.whitelist-append strchr
+
+# tell ghostscript it's OK to use the system pkg-config even when cross-compiling
+# see https://trac.macports.org/ticket/66627
+configure.env-append \
+                    DARWIN_LDFLAGS_SO_PREFIX="${prefix}/lib/" \
+                    PKGCONFIG=${prefix}/bin/pkg-config
+
+# https://trac.macports.org/ticket/56137
+configure.ldflags-prepend \
+                    -Lsobin
+
+# Make included OpenJPEG uses its own headers rather than the system ones
+configure.cppflags-replace \
+                    -I${prefix}/include \
+                    -isystem${prefix}/include
+
+configure.args-append \
+                    --disable-compile-inits \
+                    --disable-cups \
+                    --disable-dbus \
+                    --disable-gtk \
+                    --with-system-libtiff \
+                    --without-gpdl \
+                    --without-pcl \
+                    --without-tesseract \
+                    --without-x \
+                    --without-xps
+
+build.target        so
+
+destroot.target     soinstall
+post-destroot {
+    ln -s gsc ${destroot}${prefix}/bin/gs
+
+    if {[variant_isset ghostpdl]} {
+        ln -s gpcl6c ${destroot}/${prefix}/bin/gpcl6
+        ln -s gxpsc ${destroot}/${prefix}/bin/gxps
+        ln -s gpdlc ${destroot}/${prefix}/bin/gpdl
+    }
+
+    xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}
+    xinstall -m 0644 -W ${worksrcpath} \
+        LICENSE DroidSansFallback.NOTICE \
+        ${destroot}/${prefix}/share/doc/${name}
+
+    if {[variant_isset ghostpdl]} {
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl
+        xinstall -m 0644 -W ${worksrcpath}/pcl \
+            COPYING.AFPL LICENSE NEWS README.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl
+
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl/pcl
+        xinstall -m 0644 -W ${worksrcpath}/pcl/pcl \
+            Anomalies.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl/pcl
+
+        xinstall -m 755 -d ${destroot}${prefix}/share/doc/${name}/pcl/pxl
+        xinstall -m 0644 -W ${worksrcpath}/pcl/pxl \
+            pxcet.txt pxdiff.txt pxfts.txt pxlib.txt pxspec.txt \
+            ${destroot}${prefix}/share/doc/${name}/pcl/pxl
+    }
+
+    # std fonts - install into FontCache-compatible directory.
+    # Check: could break on case-sensitive file systems...
+    xinstall -m 0755 -d ${destroot}${prefix}/share/fonts/Type1/gsfonts
+    xinstall -m 0644 \
+            {*}[glob -directory ${workpath}/fonts {[a-z][0-9][0-9][0-9][0-9][0-9][0-9][a-z].*} fonts.scale fonts.dir] \
+            ${destroot}${prefix}/share/fonts/Type1/gsfonts
+
+    # Delete the already copied fonts to not copy them again when installing the "other" fonts.
+    delete {*}[glob -directory ${workpath}/fonts {[a-z][0-9][0-9][0-9][0-9][0-9][0-9][a-z].*}]
+
+    # other fonts - install into private ghostscript directory.
+    xinstall -m 755 -d ${destroot}${prefix}/share/${name}/fonts
+    xinstall -m 644 {*}[glob -directory ${workpath}/fonts *.afm *.gsf *.pfa *.pfm] \
+            ${destroot}${prefix}/share/${name}/fonts
+
+    # std fonts - "documentation"
+    xinstall -m 0755 -d ${destroot}${prefix}/share/doc/${name}/fonts
+    xinstall -m 0644 -W ${workpath}/fonts \
+            COPYING ChangeLog README README.tweaks TODO \
+            ${destroot}${prefix}/share/doc/${name}/fonts
+
+    if {[variant_isset ghostpdl]} {
+        # Install PCL base fonts into urwfonts directory
+        xinstall -m 755 -d ${destroot}${prefix}/share/${name}/urwfonts
+        xinstall -m 644 {*}[glob -directory ${worksrcpath}/pcl/urwfonts *.ttf] \
+            ${destroot}${prefix}/share/${name}/urwfonts
+    }
+}
+
+post-activate {
+    system "${prefix}/bin/fc-cache -v ${prefix}/share/fonts/Type1/gsfonts"
+}
+
+configure.universal_args-delete --disable-dependency-tracking
+
+variant x11 {
+    depends_lib-append      port:xorg-libXext
+    depends_lib-append      port:xorg-libXt
+    configure.args-replace  --without-x --with-x
+}
+
+variant cups description {Enable CUPS driver} {
+    configure.args-replace  --disable-cups --enable-cups
+}
+
+variant ghostpdl description {Install GhostPDL} {
+    license-append          noncommercial
+    depends_lib-append      port:expat
+    configure.args-replace  --without-pcl --with-pcl=gpcl6
+    configure.args-replace  --without-xps --with-xps=gxps
+    configure.args-replace  --without-gpdl --with-gpdl=gpdl
+    notes "
+    GhostPCL requires a set of truetype fonts to function properly. To use
+    the default URW font set, add the following to your shell profile:
+
+        export PCLFONTSOURCE='${prefix}/share/${name}/urwfonts/'
+
+    These fonts are distributed under the Aladdin Free Public License which
+    bars commercial use. For more information see
+    ${prefix}/share/doc/${name}/pcl/LICENSE
+    "
+}
+
+default_variants    +x11
+
+livecheck.type      regex
+livecheck.url       ${homepage}releases.html
+livecheck.regex     "Ghostscript (\\d+(?:\\.\\d+)*)"

--- a/print/ghostscript/Portfile
+++ b/print/ghostscript/Portfile
@@ -105,6 +105,21 @@ depends_run-append \
 compiler.c_standard 1999
 configure.cflags-append -std=gnu99
 
+# Older gcc 4 does not provide the header.
+# matching_tag_mask.h:15:23: error: immintrin.h: No such file or directory
+if {${configure.build_arch} eq "i386" || ${configure.build_arch} eq "x86_64"} {
+    compiler.blacklist *gcc-4.*
+}
+
+# When including macports libiconv:
+# gdevopvp.c:1685:39: error: passing argument 2 of 'libiconv' from incompatible
+# pointer type [-Wincompatible-pointer-types] 
+platform darwin 8 {
+    if {[string match macports-gcc-* ${configure.compiler}]} {
+        configure.cflags-append    -Wno-error=incompatible-pointer-types
+    }
+}
+
 use_autoreconf      yes
 autoreconf.args     -fv
 configure.checks.implicit_function_declaration.whitelist-append strchr

--- a/print/ghostscript/files/patch-base_unixinst.mak.diff
+++ b/print/ghostscript/files/patch-base_unixinst.mak.diff
@@ -1,0 +1,73 @@
+--- base/unixinst.mak.orig	2023-09-12 14:40:30
++++ base/unixinst.mak	2023-09-14 17:45:24
+@@ -78,6 +78,8 @@
+ PSEXDIR=$(PSLIBDIR)/../examples
+ PSMANDIR=$(PSLIBDIR)/../man
+ 
++PCLEXDIR=$(PSLIBDIR)/../pcl/examples
++
+ install-data: install-libdata install-resdata$(COMPILE_INITS) install-iccdata$(COMPILE_INITS) install-doc install-man
+ 
+ # There's no point in providing a complete dependency list: we include
+@@ -148,13 +150,30 @@
+ # install html documentation
+ DOC_PAGES=index.html News.html COPYING Ghostscript.pdf \
+           GS9_Color_Management.pdf
++GPDL_DOC_PAGES=ghostpdl.pdf ghostpdl.txt
+ 
+-install-doc: $(PSDOCDIR)/News.html
++install-doc: $(PSDOCDIR)/News.html install-doc-$(PCL_TARGET) install-doc-$(XPS_TARGET) install-doc-$(GPDL_TARGET)
+ 	-mkdir -p $(DESTDIR)$(docdir)
+ 	$(SH) -c 'for f in $(DOC_PAGES) ;\
+ 	do if ( test -f $(PSDOCDIR)/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/$$f $(DESTDIR)$(docdir); fi;\
+ 	done'
+ 
++install-doc-gpcl6: install-doc-gpdl
++	$(NO_OP)
++
++install-doc-gxps: install-doc-gpdl
++	$(NO_OP)
++
++install-doc-gpdl:
++	-mkdir -p $(DESTDIR)$(docdir)/pclxps
++	$(SH) -c 'for f in $(GPDL_DOC_PAGES) ;\
++	do if ( test -f $(PSDOCDIR)/pclxps/$$f ); then $(INSTALL_DATA) $(PSDOCDIR)/pclxps/$$f $(DESTDIR)$(docdir)/pclxps; fi;\
++	done'
++
++# Dummy target
++install-doc-:
++	$(NO_OP)
++
+ # install the man pages for each locale
+ MAN_LCDIRS=.
+ MAN1_LINKS_PS2PS=eps2eps
+@@ -189,7 +208,7 @@
+ 	done'
+ 
+ # install the example files
+-install-examples:
++install-examples: install-examples-$(PCL_TARGET)
+ 	-mkdir -p $(DESTDIR)$(exdir)
+ 	for f in \
+         alphabet.ps colorcir.ps escher.ps grayalph.ps snowflak.ps \
+@@ -204,6 +223,20 @@
+ all_ag1.ps all_aj2.ps article9.ps gscjk_ag.ps gscjk_ak.ps iso2022v.ps ;\
+ 	do $(INSTALL_DATA) $(PSEXDIR)/cjk/$$f $(DESTDIR)$(exdir)/cjk ;\
+ 	done
++
++install-examples-gpcl6:
++	-mkdir -p $(DESTDIR)$(exdir)/pcl
++	for f in \
++	    bitfont.pcl bitfonts.pxl fills.pcl fontpage.pcl fonts.pcl fonts.pxl \
++	    frs96.pxl gl-chars.pcl grashopp.pcl grid.pcl label.tst \
++	    lineprinter.pcl null.pxl opaque.pcl origins.pcl owl.pcl owl2.pcl \
++	    pattern.pcl pattern.pxl tiger.px3 tiger.xps .px3;\
++	do $(INSTALL_DATA) $(PCLEXDIR)/$$f $(DESTDIR)$(exdir)/pcl ;\
++	done
++
++# Dummy target
++install-examples-:
++	$(NO_OP)
+ 
+ install-shared: $(GS_SHARED_OBJS)
+ 	-mkdir -p $(DESTDIR)$(gssharedir)


### PR DESCRIPTION
I believe the gcc16 issue would impact all os versions as this occurs when using macports libiconv headers rather then system libiconv.

The i386 issue is old GCC4 versions don't have immintrin.h, this is an intel specific thing for SIMD like SSE2 (which we can actually use here as core solo/duo support up to SSE3).