### PR TITLE
aqua/aqualink: bump to v0.5.3

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.2 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.3 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  b525aeea4b0421c76eeedaf20fb936d1af2272de \
-                    sha256  a7b32c809f208df7243fb09240d41f3c455009688aa6313ee63a8e97d888e311 \
-                    size    83849
+checksums           rmd160  9cbfed9708abb69f51c24469c4ac3035297a4c30 \
+                    sha256  89168963cc3d382dcde119c574696384c4b0191081bec57b3e3dd0a99fa1b841 \
+                    size    84689
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.5.2 to 0.5.3.

While diagnosing a real auth error reported against a build using this
port's libsmb2, found that connection-failure messages weren't showing
their detail line at all — the status field displaying them is a
single-line NSTextField, so the second line (the actual underlying
error text) was simply invisible, not truncated. This blocked getting
the information needed to diagnose the report properly.

v0.5.3 also shows the full message in a dialog. Confirmed on real
Tiger hardware. See smb3/README.md.