### PR TITLE
py-cairo: allow tiger x11 only variant to match current cairo+x11 port behavior

### DIFF
--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -64,11 +64,11 @@ if {${name} ne ${subport}} {
         require_active_variants cairo x11
     }
 
-    if {[catch {active_variants cairo quartz} result] || $result} {
+    if {![catch {active_variants cairo quartz} result] && $result} {
         default_variants-append +quartz
     }
 
-    if {[catch {active_variants cairo x11} result] || $result} {
+    if {![catch {active_variants cairo x11} result] && $result} {
         default_variants-append +x11
     }
 

--- a/python/py-cairo/Portfile
+++ b/python/py-cairo/Portfile
@@ -1,0 +1,76 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem              1.0
+PortGroup               active_variants 1.1
+PortGroup               github 1.0
+PortGroup               python 1.0
+
+github.setup            pygobject pycairo 1.29.1 v
+name                    py-cairo
+github.tarball_from     releases
+revision                0
+
+categories-append       graphics
+license                 {LGPL-2.1 MPL-1.1}
+maintainers             {reneeotten @reneeottn} openmaintainer
+
+description             Pycairo is set of Python bindings for the cairo graphics library
+long_description        {*}${description}
+
+checksums               rmd160  6f443f47ac6454a861077be3caec45eacafb4c3f \
+                        sha256  4fbd26b4af24c9787d84cf5448e34eb8dca064b732479aaecd03109520eebd5f \
+                        size    666272
+
+python.versions         27 36 310 311 312 313 314
+
+if {${name} ne ${subport}} {
+    depends_build-append    path:bin/pkg-config:pkgconfig \
+                            port:py${python.version}-cython \
+                            port:py${python.version}-setuptools
+
+    if {${python.version} == 27} {
+        github.setup    pygobject pycairo 1.18.2 v
+        revision        0
+        checksums       rmd160  49a2ed4c9cf5c2606e7cf7c9693bceff40a1bebf \
+                        sha256  dcb853fd020729516e8828ad364084e752327d4cff8505d20b13504b32b16531 \
+                        size    200462
+    } elseif {${python.version} == 36} {
+        github.setup    pygobject pycairo 1.20.1 v
+        revision        0
+        checksums       rmd160  7e4477f3067503c40b6e31d985b21cf6c214acc2 \
+                        sha256  1ee72b035b21a475e1ed648e26541b04e5d7e753d75ca79de8c583b25785531b \
+                        size    344639
+    } else {
+        python.pep517_backend meson
+
+        depends_test-append port:py${python.version}-hypothesis
+
+        test.run            yes
+        test.env-append     PYTHONPATH=${destroot}${python.pkgd}
+    }
+
+    depends_lib-append      path:lib/pkgconfig/cairo.pc:cairo \
+                            path:lib/pkgconfig/glib-2.0.pc:glib2
+
+    # cairo/surface.c:478: error: #pragma GCC diagnostic not allowed inside functions
+    # early clang versions don't use CPATH
+    compiler.blacklist-append *gcc-3.* *gcc-4.* {clang < 300}
+
+    variant quartz {
+        require_active_variants cairo quartz
+    }
+
+    variant x11 {
+        require_active_variants cairo x11
+    }
+
+    if {[catch {active_variants cairo quartz} result] || $result} {
+        default_variants-append +quartz
+    }
+
+    if {[catch {active_variants cairo x11} result] || $result} {
+        default_variants-append +x11
+    }
+
+    livecheck.type      none
+}


### PR DESCRIPTION
I believe this corrects to the intended behavior. If I have cairo+x11, right now, the current portfile of py-cairo in macports wants py-cairo+x11+xquartz. I believe this to be a bug, because that doesn't quite make sense to me. I'm not even sure if xquartz builds yet for tiger. This is part of the libsdl2+pulseaudio+opengl dependency chain. This commit changes it so it requests py-cairo+x11 by checking the variant