### PR TITLE
aqua/aqualink: bump to v0.5.4

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.3 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.4 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  9cbfed9708abb69f51c24469c4ac3035297a4c30 \
-                    sha256  89168963cc3d382dcde119c574696384c4b0191081bec57b3e3dd0a99fa1b841 \
-                    size    84689
+checksums           rmd160  0a0b695bc9328261ab45ac675e88891fc83db1be \
+                    sha256  a18d5dadac0e474ba9d276503e44850be0931a66e41c2e0648add3127b3c7be8 \
+                    size    85319
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps `aqua/aqualink` from 0.5.3 to 0.5.4.

Upstream v0.5.4 is a batch of UI fixes for the file-browser window, all
verified on an iBook G4 running Tiger 10.4.11:

- "Up" button relabelled "▲ Up" and widened so the longer label is not
  clipped; adds a ⌘↑ key equivalent matching Finder's "enclosing folder".
- Rounded-bezel buttons whose top edge was eaten by the glyph at 22px
  height are bumped to 26px.
- The directory listing now hides every dotfile (`.DS_Store`, `.lesshst`,
  …) instead of only `.DS_Store`.

No build-system or dependency changes; the Portfile delta is version +
checksums only.

Checksums verified against
https://github.com/watermark-hd/ppc-mac-modernization/archive/refs/tags/v0.5.4.tar.gz