### PR TITLE
aqua/aqualink: bump to v0.5.6

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.5 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.6 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  d07341060afbd0f083727caef7e5a166db32af6b \
-                    sha256  cccd61ccb160effcc6a207d8404d9c41755cdaa735d4401ef73f83b3f597c6d2 \
-                    size    89097
+checksums           rmd160  f4322d46bfafdcfa8e846be481a3c638012e42f4 \
+                    sha256  24957ca7ff5cf83e8353468ba8d1906213b550bd4e79a41e9a4af74b16a5ebb0 \
+                    size    90863
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink

--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.4 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.5 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  0a0b695bc9328261ab45ac675e88891fc83db1be \
-                    sha256  a18d5dadac0e474ba9d276503e44850be0931a66e41c2e0648add3127b3c7be8 \
-                    size    85319
+checksums           rmd160  d07341060afbd0f083727caef7e5a166db32af6b \
+                    sha256  cccd61ccb160effcc6a207d8404d9c41755cdaa735d4401ef73f83b3f597c6d2 \
+                    size    89097
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps `aqua/aqualink` to 0.5.6. (Updated in place from the earlier 0.5.5
bump on this branch, since that had not been merged yet.)

Since 0.5.4, upstream added:

- **v0.5.5** -- file-browser list reworked toward a Transmit/Cyberduck
  layout: folder/file icons in the Name column, the text "Kind" column
  dropped, a new "Modified" column, and right-aligned fixed-width
  Size/Modified with only the Name column growing on resize.
- **v0.5.6** -- click a column header to sort the list by Name, Size, or
  Modified (click again to reverse); folders stay grouped first.

No build-system or dependency changes; the Portfile delta is version +
checksums only.

Checksums verified against
https://github.com/watermark-hd/ppc-mac-modernization/archive/refs/tags/v0.5.6.tar.gz