### PR TITLE
libfmt12: undef tiger sdk macro before base.h macro clashes

### DIFF
--- a/devel/libfmt12/Portfile
+++ b/devel/libfmt12/Portfile
@@ -82,6 +82,13 @@ pre-activate {
     }
 }
 
+# Tiger SDK has conflicting isalpha macro from ctype.h that must be undef'd.
+platform darwin 8 {
+    revision 1 
+    patchfiles-append \
+        include_fmt_base.h_tiger.diff
+}
+
 variant tests description "Enable test support" {
     PortGroup       conflicts_build 1.0
 

--- a/devel/libfmt12/files/include_fmt_base.h_tiger.diff
+++ b/devel/libfmt12/files/include_fmt_base.h_tiger.diff
@@ -1,0 +1,20 @@
+--- include/fmt/base.h.orig	2026-09-10 20:05:17.000000000 -0600
++++ include/fmt/base.h	2026-09-10 20:05:33.000000000 -0600
+@@ -891,6 +891,17 @@
+ #  define FMT_USE_LOCALE (FMT_OPTIMIZE_SIZE <= 1)
+ #endif
+ 
++// Mac OS X 10.4u SDK has conflicting isalpha macro from ctype.h that has a
++// name clash: isalpha(c) __istype((c), _CTYPE_A)
++#if defined(__APPLE__)
++#  include <AvailabilityMacros.h>
++#  if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++#    ifdef isalpha
++#      undef isalpha
++#    endif
++#  endif
++#endif
++
+ // A type-erased reference to std::locale to avoid the heavy <locale> include.
+ class locale_ref {
+ #if FMT_USE_LOCALE


### PR DESCRIPTION
In ctypes.h of tiger sdk, there exists a macro of the same name with different signature that is unrelated, which for example when using this header while building doxygen on tiger causes the build to fail