### PR TITLE
doxygen: fix tiger fallback checksums

### DIFF
--- a/textproc/doxygen/Portfile
+++ b/textproc/doxygen/Portfile
@@ -21,6 +21,20 @@ version                 1.18.0
 revision                0
 epoch                   2
 
+checksums               rmd160  91f625d6fcfe87a511ef1e356e7fa14f5dcaf190 \
+                        sha256  a1deed70a6785bbec95a2b2a9e419dc7f7b223a9d74a8644ae611c8e2dcdd354 \
+                        size    9905783
+
+if {${os.platform} eq "darwin" && ${os.major} < 9} {
+    #use fallback on Tiger since current version doesn't build and doxygen is usually just a build time dependency
+    version                 1.17.0
+    revision                2
+
+    checksums               rmd160  e9546ecf9acb30d8bf905ce877e07ecd7f4a3f5d \
+                            sha256  fa4c3dd78785abc11ccc992bc9c01e7a8c3120fe14b8a8dfd7cefa7014530814 \
+                            size    9350308
+}
+
 categories              textproc devel
 license                 GPL-2
 maintainers             nomaintainer
@@ -48,10 +62,6 @@ master_sites            ${homepage}/files
 distname                ${my_name}-${version}
 dist_subdir             ${my_name}
 distfiles               ${distname}.src${extract.suffix}
-
-checksums               rmd160  91f625d6fcfe87a511ef1e356e7fa14f5dcaf190 \
-                        sha256  a1deed70a6785bbec95a2b2a9e419dc7f7b223a9d74a8644ae611c8e2dcdd354 \
-                        size    9905783
 
 set py_ver              3.14
 set py_ver_nodot        [string map {. {}} ${py_ver}]
@@ -108,16 +118,8 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
 }
 
 if {${os.platform} eq "darwin" && ${os.major} < 9} {
-    #use fallback on Tiger since current version doesn't build and doxygen is usually just a build time dependency
-    version                 1.17.0
-    revision                2
-    epoch                   2
-    checksums               rmd160  e9546ecf9acb30d8bf905ce877e07ecd7f4a3f5d \
-                            sha256  fa4c3dd78785abc11ccc992bc9c01e7a8c3120fe14b8a8dfd7cefa7014530814 \
-                            size    9350308
-
-    if {[string match "macports-gcc-*" ${configure.compiler}]} {
-        configure.cflags-append "-Wno-error=incompatible-pointer-types"
+    if {[string match macports-gcc-* ${configure.compiler}]} {
+        configure.cflags-append    -Wno-error=incompatible-pointer-types
     }
 }
 


### PR DESCRIPTION
The issue here is the distfile/version is set well before we get to where it is changed currently for tiger, this is the cleanest way to fix it and mirrors tuntaposx pr.

This in combination with the libfmt12 pr restores doxygen for tiger