### PR TITLE
minizip-ng: don't mandate O_NOFOLLOW for tiger and lower

### DIFF
--- a/archivers/minizip-ng/Portfile
+++ b/archivers/minizip-ng/Portfile
@@ -1,0 +1,82 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           cmake 1.1
+PortGroup           github 1.0
+PortGroup           openssl 1.0
+
+github.setup        zlib-ng minizip-ng 4.2.2
+revision            0
+checksums           rmd160  41561c2aa39a12ca68e088c305e2f1251fef0654 \
+                    sha256  71af7b9799856d8b03619df3949e9c1be9703f8de0795af71399ba283cb27aac \
+                    size    611941
+
+categories          archivers
+maintainers         {ryandesign @ryandesign} openmaintainer
+license             zlib
+
+description         fork of zlib's minizip zip file manipulation library
+
+long_description    ${name} is a {*}${description}.
+
+github.tarball_from archive
+
+depends_build-append \
+                    path:bin/pkg-config:pkgconfig
+
+depends_lib-append  port:bzip2 \
+                    port:libiconv \
+                    port:xz \
+                    port:zstd
+
+# see https://lists.macports.org/pipermail/macports-dev/2023-May/045008.html
+depends_run-append  port:zstdConfig.cmake
+
+configure.args      -DBUILD_SHARED_LIBS=ON \
+                    -DMZ_BUILD_TEST=OFF \
+                    -DMZ_BUILD_UNIT_TEST=OFF \
+                    -DMZ_BZIP2=ON \
+                    -DMZ_FETCH_LIBS=OFF \
+                    -DMZ_ICONV=ON \
+                    -DMZ_LIBCOMP=OFF \
+                    -DMZ_LZMA=ON \
+                    -DMZ_OPENSSL=ON \
+                    -DMZ_PPMD=OFF \
+                    -DMZ_ZLIB=OFF \
+                    -DMZ_ZSTD=ON
+
+# Disable minizip compatibility mode to avoid conflict with libzip port.
+configure.args-append \
+                    -DMZ_COMPAT=OFF
+
+# Disable signing support because its tests fail unless a test
+# certificate is installed in the keychain.
+# https://github.com/zlib-ng/minizip-ng/issues/580#issuecomment-874894055
+configure.args-append \
+                    -DMZ_SIGNING=OFF
+
+if {${os.platform} eq "darwin" && ${os.major} >= 15} {
+    # Use Apple's libcompression.dylib.
+    configure.args-replace \
+                    -DMZ_LIBCOMP=OFF    -DMZ_LIBCOMP=ON
+} else {
+    # libcompression.dylib not available; use zlib.
+    depends_lib-append \
+                    port:zlib
+    configure.args-replace \
+                    -DMZ_ZLIB=OFF       -DMZ_ZLIB=ON
+}
+
+variant tests description {Enable tests} {
+    # if gtest not found, test/CMakeLists.txt helpfully downloads a copy and builds it regardless of MZ_FETCH_LIBS
+    depends_test-append \
+                    port:gtest
+
+    configure.args-replace \
+                    -DMZ_BUILD_TEST=OFF         -DMZ_BUILD_TEST=ON \
+                    -DMZ_BUILD_UNIT_TEST=OFF    -DMZ_BUILD_UNIT_TEST=ON
+
+    test.run        yes
+    # duplicate ${test.dir}/Makefile with DYLD_LIBRARY_PATH
+    test.cmd        DYLD_LIBRARY_PATH=${cmake.build_dir} ctest --force-new-ctest-process
+}

--- a/archivers/minizip-ng/Portfile
+++ b/archivers/minizip-ng/Portfile
@@ -67,6 +67,11 @@ if {${os.platform} eq "darwin" && ${os.major} >= 15} {
                     -DMZ_ZLIB=OFF       -DMZ_ZLIB=ON
 }
 
+# Adds support for not having O_NOFOLLOW.
+platform darwin 8 {
+    patchfiles-append    no_o_nofollow_tiger.diff 
+}
+
 variant tests description {Enable tests} {
     # if gtest not found, test/CMakeLists.txt helpfully downloads a copy and builds it regardless of MZ_FETCH_LIBS
     depends_test-append \

--- a/archivers/minizip-ng/files/no_o_nofollow_tiger.diff
+++ b/archivers/minizip-ng/files/no_o_nofollow_tiger.diff
@@ -1,0 +1,42 @@
+--- mz.h.orig	2026-06-30 10:44:28.000000000 -0600
++++ mz.h	2026-09-06 14:52:02.000000000 -0600
+@@ -54,6 +54,13 @@
+ #define MZ_OPEN_MODE_CREATE    (0x08)
+ #define MZ_OPEN_MODE_EXISTING  (0x10)
+ #define MZ_OPEN_MODE_NOFOLLOW  (0x20)
++/* Mac OS X 10.4 and below does not have O_NOFOLLOW */
++#if defined(__APPLE__)
++#include <AvailabilityMacros.h>
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++#define NO_O_NOFOLLOW
++#endif
++#endif
+ 
+ /* MZ_SEEK */
+ #define MZ_SEEK_SET (0)
+--- mz_strm_os_posix.c.orig	2026-09-06 13:09:30.000000000 -0600
++++ mz_strm_os_posix.c	2026-09-06 13:55:06.000000000 -0600
+@@ -89,8 +89,10 @@
+     } else
+         return MZ_OPEN_ERROR;
+ 
++    #ifndef NO_O_NOFOLLOW
+     if (mode & MZ_OPEN_MODE_NOFOLLOW)
+         mode_open |= O_NOFOLLOW;
++    #endif
+ 
+     fd = open(path, mode_open, S_IRUSR | S_IWUSR | S_IRGRP);
+     if (fd != -1) {
+--- mz_zip_rw.c.orig	2026-09-06 13:41:48.000000000 -0600
++++ mz_zip_rw.c	2026-09-06 13:53:26.000000000 -0600
+@@ -1704,8 +1704,10 @@
+         stream = mz_stream_os_create();
+         if (!stream)
+             return MZ_STREAM_ERROR;
++        #ifndef NO_O_NOFOLLOW
+         if (!writer->follow_links)
+             mode |= MZ_OPEN_MODE_NOFOLLOW;
++        #endif
+         err = mz_stream_os_open(stream, path, mode);
+     }
+ 


### PR DESCRIPTION
While this is a platform darwin 8 block here, it technically fixes it for lower as well once I get it to upstream