### PR TITLE
expat: remove rpath from cmake config on tiger

### DIFF
--- a/textproc/expat/Portfile
+++ b/textproc/expat/Portfile
@@ -23,6 +23,11 @@ checksums           rmd160  e90e6523b6b69a3969502b1276635e16a376c48d \
                     sha256  963250a823c16a498582b4ad82ad0f88926be0769675d3b6956be4d769a1cd8f \
                     size    666106
 
+# Signify rpath fix.
+platform darwin 8 {
+    incr revision
+}
+
 # Don't use a compression format that necessitates a dependency on another
 # port since that causes a dependency cycle on older OS versions since
 # e.g. clang-3.4 depends on python27-bootstrap which depends on expat.
@@ -62,6 +67,11 @@ if {${os.platform} eq "darwin" && ${os.major} < 13} {
 }
 
 post-destroot {
+    # If expat has an @rpath, it will fail on 10.4 when checked by cmake.
+    # Simply remove the @rpath and replace it with an absolute path.
+    if {${os.platform} eq "darwin" && ${os.major} < 9} {
+        reinplace "s|@rpath/libexpat.1.dylib|${prefix}/lib/libexpat.1.dylib|g" ${destroot}${prefix}/lib/cmake/expat-${version}/expat-noconfig.cmake
+    }
     set docdir ${destroot}${prefix}/share/doc/${name}
     set examplesdir ${destroot}${prefix}/share/examples/${name}
     xinstall -m 0755 -d ${examplesdir} ${docdir}/html


### PR DESCRIPTION
When opencolorio tries to use expat on tiger, configuration fails due to the @rpath 

CMake Error at /opt/local/lib/cmake/expat-2.8.4/expat.cmake:59 (add_library):
  Attempting to use @rpath without CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG being
  set. This could be because you are using a Mac OS X version less than 10.5
  or because CMake's platform configuration is corrupt.

So on 10.4, reinplace the rpath with an absolute path based on prefix