### PR TITLE
mplayer: use correct sdl dep

### DIFF
--- a/multimedia/MPlayer/Portfile
+++ b/multimedia/MPlayer/Portfile
@@ -47,7 +47,7 @@ depends_lib-append  port:aom \
                     port:libxml2 \
                     port:lzo2 \
                     port:ncurses \
-                    port:libsdl2 \
+                    port:libsdl \
                     path:lib/libspeex.dylib:speex \
                     port:zlib
 


### PR DESCRIPTION
mplayer uses sdl1, not sdl2. So when building this, it pulls in libsdl2 but then never finds sdl.

Curiously, official macports disables sdl: https://github.com/macports/macports-ports/blob/db439281734923e731f8c6a86bb6631d74bdbd45/multimedia/MPlayer/Portfile#L66

Apparently, libsdl port is now a wrapper for sdl2 for newer operating systems: https://github.com/macports/macports-ports/blob/master/devel/libsdl/Portfile but for older ones it uses real sdl1 (and tiger still works).

Sure enough, trying to build libsdl12-compat fails on tiger due to objc abi (the above stays working however because it uses actual sdl1 on older operating systems). 

By enabling sdl, OTB we get a 1080p playback  on G5 tiger (pretty competent anyways, some minor slowdown with youtube H264 rips but hey, powervlc does that too and I haven't even upgraded my GPU yet in my early 05 dual 2ghz nor tried the 'G5' variant, or done much other additional flags/config).

The best thing to do here is mplayer -vo gl_nosw -ao sdl on G5 tiger for performance (-vo sdl is much too slow as it's to my understanding software based do to using actual sdl1 port on tiger). SDL is what enables the various gl based vos btw, there is currently zero video outs available if you didn't happen to install libsdl.

Hope this makes sense! @ForestExpertise may be interested in this as well.
 