### PR TITLE
aqua/aqualink: bump to v0.5.9

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.6 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.9 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  f4322d46bfafdcfa8e846be481a3c638012e42f4 \
-                    sha256  24957ca7ff5cf83e8353468ba8d1906213b550bd4e79a41e9a4af74b16a5ebb0 \
-                    size    90863
+checksums           rmd160  ff5e01994e2216c40119b1be946f4d5afa96f5fa \
+                    sha256  59724900f6d99fa122b0e08efb9d5657007b4b7ef0d63bf9f2a4a48fbf25e6fa \
+                    size    94376
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.5.6 to 0.5.9.

v0.5.7–v0.5.9 add Bonjour discovery of SMB servers on the local network
to the address field's drop-down, so you can pick a NAS or a shared Mac
without knowing its IP. It uses the resolved numeric address rather than
the hostname, so it also works where name resolution itself is broken.
(v0.5.7 introduced it; v0.5.8/v0.5.9 fixed an em-dash mojibake and a
combo-box selection bug — v0.5.9 is the first working build.)

Verified on an iBook G4 running Mac OS X 10.4.11.