### PR TITLE
aqua/aqualink: bump to v0.5.10

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.9 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.10 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  ff5e01994e2216c40119b1be946f4d5afa96f5fa \
-                    sha256  59724900f6d99fa122b0e08efb9d5657007b4b7ef0d63bf9f2a4a48fbf25e6fa \
-                    size    94376
+checksums           rmd160  642b8b6f4a79efbcf2d578808f8edeb8aa7b1c35 \
+                    sha256  84b0873295922965893932ed79f8f9285af33655a0e7f33832929f92e61aa215 \
+                    size    95543
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.5.9 to 0.5.10.

Small reliability fixes for `Connect in Finder` (the WebDAV loopback mount):
a failed mount now raises a dialog instead of only a status-bar line, and
AquaLink checks that `/sbin/mount_webdav` still has its setuid bit before
trying (OS updates strip it, which makes every mount fail; the dialog then
shows the one-line fix). Verified on an iBook G4 running 10.4.11.