### PR TITLE
aqua/aqualink: bump to v0.5.11

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.10 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.11 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  642b8b6f4a79efbcf2d578808f8edeb8aa7b1c35 \
-                    sha256  84b0873295922965893932ed79f8f9285af33655a0e7f33832929f92e61aa215 \
-                    size    95543
+checksums           rmd160  b8cb2f6784017228a8574702c1cee7ad027ed5e3 \
+                    sha256  05f4a40ccf44c6aa7fb97b747802e562ceeb3e4cd0fd68c92f369bcd713da9f0 \
+                    size    96818
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Bumps aqua/aqualink from 0.5.10 to 0.5.11.

Adds a standard Edit menu — the hand-built menu bar had none, so
Cmd-C/V/X/A did nothing in any text field. After a successful
`Connect in Finder` mount, AquaLink now opens the mounted volume in
Finder (it mounts on the machine running AquaLink; Finder prefs can
otherwise hide the icon). Verified on an iBook G4 running 10.4.11.