### PR TITLE
libsdl2: more agressive/optimized buffer patch from cygwin for pulseaudio variant(s)

### DIFF
--- a/devel/libsdl2/Portfile
+++ b/devel/libsdl2/Portfile
@@ -193,6 +193,11 @@ variant pulseaudio description "Build with PulseAudio support" {
 
     configure.args-replace \
                     --disable-pulseaudio --enable-pulseaudio
+
+    # Smaller more agressive buffers like Cygwin to fix initial audio delay on 
+    # audio device open to fill buffer and sync issues. Tested with FFplay.
+    incr revision
+    patchfiles-append    src_pulseaudio_sdl_pulseaudio.c_trim_buffers.diff
 }
 
 variant samplerate description "Build with libsamplerate support" {

--- a/devel/libsdl2/files/src_pulseaudio_sdl_pulseaudio.c_trim_buffers.diff
+++ b/devel/libsdl2/files/src_pulseaudio_sdl_pulseaudio.c_trim_buffers.diff
@@ -1,0 +1,13 @@
+--- src/audio/pulseaudio/SDL_pulseaudio.c.orig	2026-09-09 10:13:30.000000000 -0600
++++ src/audio/pulseaudio/SDL_pulseaudio.c	2026-09-09 10:24:40.000000000 -0600
+@@ -663,8 +663,8 @@
+     /* Reduced prebuffering compared to the defaults. */
+     paattr.fragsize = this->spec.size;
+     paattr.tlength = h->mixlen;
+-    paattr.prebuf = -1;
+-    paattr.maxlength = -1;
++    paattr.prebuf = iscapture ? -1 : 0;
++    paattr.maxlength = iscapture ? -1 : (h->mixlen * 2);
+     paattr.minreq = -1;
+     flags |= PA_STREAM_ADJUST_LATENCY;
+ 


### PR DESCRIPTION
Pulseaudio on audio device open implemented by SDL2 waits for it's buffer to fill with sound data before it starts playing (to conservatively prevent buffer underruns). When using it directly as an audio out with SDL (tested with ffplay as that's the easist thing to build right now under tiger) this is noticeable as there is an audible delay until audio starts. This desyncs video playback with a ~1 second audio latency delay, lip syncing is off, etc. I noticed that when switching pulse audio sinks (internal speaker/headphone to my usb sound card to bluetooth adapter) back and forth it 're-negotiated' the latency/buffer sync and fixed the delay.

This [patch is from cygwin](https://cygwin.com/git/?p=git/cygwin-packages/SDL2.git;a=commitdiff;h=83a1059d34f39abd3f0e8cfd5bb8507152f00d80;ds=inline), where they have SDL also using pulseaudio as an audio out. And after much testing it essentially does the behavior that switching sinks does by default when starting an audio stream. I did test this for over a day with a ton of different 720p YouTube videos with FFplay just to make sure this info above is accurate. I also did not encounter any buffer underuns during any testing, coreaudio feeds pulse data fast enough consistently.

When detecting pulseaudio variant I have done incr revision to signify SDL2 stuff should be rebuilt.

Since more SDL2 stuff builds on 10.6 currently, any more testing/comparison pre-patch/post-patch would be appreciated