### PR TITLE
aqua/aqualink: bump to v0.5.15

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.11 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.15 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  b8cb2f6784017228a8574702c1cee7ad027ed5e3 \
-                    sha256  05f4a40ccf44c6aa7fb97b747802e562ceeb3e4cd0fd68c92f369bcd713da9f0 \
-                    size    96818
+checksums           rmd160  357a8b0c2b69455cd8270e12f59582d3206505c9 \
+                    sha256  2808ca4e3ad0493fb2a5e885d4d2e7ca448e7a437ee28f88b539e46dcb489daa \
+                    size    106070
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink

--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.10 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.11 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  642b8b6f4a79efbcf2d578808f8edeb8aa7b1c35 \
-                    sha256  84b0873295922965893932ed79f8f9285af33655a0e7f33832929f92e61aa215 \
-                    size    95543
+checksums           rmd160  b8cb2f6784017228a8574702c1cee7ad027ed5e3 \
+                    sha256  05f4a40ccf44c6aa7fb97b747802e562ceeb3e4cd0fd68c92f369bcd713da9f0 \
+                    size    96818
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Fixes a real-machine issue where "Unmount" could fail permanently
("Operation not permitted") even with the admin password entered, on
at least one otherwise-ordinary Tiger install (both the GUI
admin-password path and a GUI-authorized shell command failed the
same way, while a `sudo umount` typed in Terminal succeeded).

The fix bundles a small setuid-root helper binary that AquaLink forks
directly (the same technique `/sbin/mount_webdav` itself already uses),
instead of going through the GUI authorization dialog, which appears to
run in a different login session than the one that created the mount
on this filesystem. It only ever accepts paths under `/Volumes/`.

Also fixes:
- The "Unmount" button getting stuck showing "Unmount" after the
  volume was already unmounted by other means (e.g. ejected directly
  from Finder).
- A leftover Finder desktop icon after unmounting, caused by the raw
  unmount bypassing DiskArbitration's usual notification.

Supersedes #276 (v0.5.11), which is now behind -- closing that one in
favor of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)