### PR TITLE
aqua/aqualink: bump to v0.5.17

### DIFF
--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.16 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.17 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  bb7e04caae18ad4c38148c46e1f538f83a7283be \
-                    sha256  65e1f2c58efb9d6ba0ce0a995cfddb7880ee191982eeefb820843f867de3bf7d \
-                    size    108276
+checksums           rmd160  ff204f0dd3e7f95b4678a20e382a593233bb3813 \
+                    sha256  f9f8d7bd92ef282a235d1905a70760597f4baaf4e1ef078452385dee878b3313 \
+                    size    112038
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink

--- a/aqua/aqualink/Portfile
+++ b/aqua/aqualink/Portfile
@@ -5,7 +5,7 @@ PortGroup           github 1.0
 PortGroup           makefile 1.0
 
 name                aqualink
-github.setup        watermark-hd ppc-mac-modernization 0.5.15 v
+github.setup        watermark-hd ppc-mac-modernization 0.5.16 v
 revision            0
 categories          aqua net
 # license             unknown
@@ -22,9 +22,9 @@ long_description    AquaLink lets PowerPC Macs running Tiger or Leopard connect 
                     includes the reverse: exposing a folder on the old Mac as a WebDAV \
                     share that a modern Mac or Windows machine can mount.
 
-checksums           rmd160  357a8b0c2b69455cd8270e12f59582d3206505c9 \
-                    sha256  2808ca4e3ad0493fb2a5e885d4d2e7ca448e7a437ee28f88b539e46dcb489daa \
-                    size    106070
+checksums           rmd160  bb7e04caae18ad4c38148c46e1f538f83a7283be \
+                    sha256  65e1f2c58efb9d6ba0ce0a995cfddb7880ee191982eeefb820843f867de3bf7d \
+                    size    108276
 github.tarball_from archive
 
 worksrcdir          ppc-mac-modernization-${version}/smb3/AquaLink


### PR DESCRIPTION
Fixes a crash in the file browser's list view found on a real PowerMac
G4, most reliably triggered by selecting a row and then scrolling.

The icon+text cell used for filenames kept "the image to draw" in a
custom ivar. Selecting a row makes NSTableView briefly duplicate that
cell internally for the highlighted look, and something about that
duplication corrupted the ivar, ending in EXC_BAD_ACCESS. A related
issue -- mutating a *shared, cached* icon image's orientation flag on
every row redraw, even though many rows share the same icon object --
likely made it worse.

Rather than chase the exact mechanism further, the cell no longer
keeps any custom ivar: it stores just the file extension in NSCell's
standard `representedObject` and looks the icon up fresh from cache at
draw time, so AppKit's own (Apple-maintained) cell-copy handling is
responsible for copying it correctly.

Supersedes the previous v0.5.16 bump on this same branch/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)