### PR TITLE
cairo: fix distfile fetch

### DIFF
--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -29,8 +29,7 @@ long_description            Cairo is a ${description}. It is designed to produce
                             advantage of display hardware acceleration when \
                             available (e.g. through the X Render Extension).
 homepage                    https://www.cairographics.org
-master_sites                ${homepage}/releases/ \
-                            https://gitlab.freedesktop.org/cairo/cairo/-/archive/${version}/
+master_sites                ${homepage}/releases/
 dist_subdir                 ${my_name}
 distname                    ${my_name}-${version}
 use_xz                      yes


### PR DESCRIPTION
This doesn't work anymore because it's fetching html containing a redirect. If I remove this second line (like MacPorts has it right now) it does work: https://github.com/macports/macports-ports/blob/8949faaf0324208a6e920fa721a9576082c00fe1/graphics/cairo/Portfile#L29