### PR TITLE
xclock: use -f for autoreconf

### DIFF
--- a/x11/xclock/Portfile
+++ b/x11/xclock/Portfile
@@ -22,6 +22,7 @@ checksums           rmd160  8bcfae78d8631389c5efeb8b32c988c6ee6f2fca \
                     size    31735
 
 use_autoreconf      yes
+autoreconf.args     -fiv
 
 depends_build-append \
                     path:bin/pkg-config:pkgconfig \


### PR DESCRIPTION
I checked macports-ports and they [don't have any autoreconf](https://github.com/macports/macports-ports/blob/master/x11/xclock/Portfile) once downloaded, if I do that I get: 
```
SOURCE_DATE_EPOCH='1789255477'
Executing:  cd "/opt/local/var/macports/build/xclock-236e6181/work/xclock-1.1.1" && ./configure --prefix=/opt/local 
DEBUG: system:  cd "/opt/local/var/macports/build/xclock-236e6181/work/xclock-1.1.1" && ./configure --prefix=/opt/local 
sh: line 1: ./configure: No such file or directory
Command failed:  cd "/opt/local/var/macports/build/xclock-236e6181/work/xclock-1.1.1" && ./configure --prefix=/opt/local 
Exit code: 127
Error: Failed to configure xclock: configure failure: command execution failed
DEBUG: Error code: NONE
DEBUG: Backtrace: configure failure: command execution failed
    while executing
"$procedure $targetname"
Error: See /opt/local/var/macports/logs/_opt_local_var_macports_sources_tigerports.com_macports_release_x11_xclock/xclock/main.log for details.
Error: Follow https://guide.macports.org/#project.tickets if you believe there
is a bug.
Error: Processing of port xclock failed
g5:~ alex$ 
```
So I assume this is something you added since your port is newer. Anyways specifically this is referring config.rpath so this is _probably_ tiger specific.
