### PR TITLE
xorg: use xorg-server-1.18 for tiger

### DIFF
--- a/x11/xorg/Portfile
+++ b/x11/xorg/Portfile
@@ -1,0 +1,45 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+
+name                xorg
+version             20090316
+categories          x11
+maintainers         {jeremyhu @jeremyhu} openmaintainer
+license             Permissive
+
+supported_archs     noarch
+
+description         The X Window System
+long_description    \
+    X11, or X, is a vendor-neutral, system-architecture neutral     \
+    network-transparent window system and user interface standard.  \
+    In other words, it is a GUI for UNIX. X can use your network --     \
+    you may run CPU-intensive programs on high powered workstations \
+    and display the user interface, the windows, on inexpensive     \
+    desktop machines.
+
+platforms           any
+homepage            https://www.x.org/
+
+depends_run         port:xorg-apps \
+                    path:bin/Xquartz:xorg-server \
+                    port:quartz-wm
+
+# use xorg-server-legacy on 10.10 and less, for now at least
+platform darwin {
+    if {${os.major} < 15} {
+        depends_run-replace path:bin/Xquartz:xorg-server \
+                            path:bin/Xquartz:xorg-server-legacy
+    }
+}
+
+distfiles
+use_configure       no
+build               {}
+destroot {
+    xinstall -d ${destroot}${prefix}/share/doc/${name}
+    system "echo ${long_description} > ${destroot}${prefix}/share/doc/${name}/README.txt"
+}
+
+livecheck.type      none

--- a/x11/xorg/Portfile
+++ b/x11/xorg/Portfile
@@ -26,9 +26,13 @@ depends_run         port:xorg-apps \
                     path:bin/Xquartz:xorg-server \
                     port:quartz-wm
 
+# Tiger lacks spawn.h, limiting xorg-server to v1.18
 # use xorg-server-legacy on 10.10 and less, for now at least
 platform darwin {
-    if {${os.major} < 15} {
+    if {${os.major} < 9} {
+        depends_run-replace path:bin/Xquartz:xorg-server \
+                            path:bin/Xquartz:xorg-server-1.18
+    } elseif {${os.major} < 15} {
         depends_run-replace path:bin/Xquartz:xorg-server \
                             path:bin/Xquartz:xorg-server-legacy
     }


### PR DESCRIPTION
MacPorts (for now) still carries xorg-server-1.18. As stated in this ticket: https://trac.macports.org/ticket/62654 we can't use anything newer because of spawn.h requirement which tiger doesn't have.

 Everything works from /Applications/MacPorts/X11.app.

Also, executing: `/Applications/MacPorts/X11.app/Contents/MacOS/X11.bin` does launch it from over SSH or terminal. 
startx however, isn't working:

```
g5:~ alex$ startx
font_cache: Scanning user font directories to generate X11 font caches
font_cache: Updating FC cache
font_cache: Done
xauth:  file /Users/alex/.serverauth.22189 does not exist

Unrecognized option: --listenonly
```

I see there is code to handle --listenonly:
```
g5:~ alex$ sudo port extract xorg-server-1.18
Password:
--->  Fetching distfiles for xorg-server-1.18
--->  Verifying checksums for xorg-server-1.18
--->  Extracting xorg-server-1.18
g5:~ alex$ cd $(port work xorg-server-1.18)
g5:/opt/local/var/macports/build/xorg-server-1.18-583abf22/work alex$ grep -rn 'listenonly' .
./xorg-server-1.18.4/hw/xquartz/mach-startup/bundle-main.c:703:        if (!strcmp(argv[i], "--listenonly")) {
./xorg-server-1.18.4/hw/xquartz/mach-startup/stub.c:277:            _argv[1] = "--listenonly";
./xorg-server-1.18.4/hw/xquartz/mach-startup/stub.c:280:                    "Xquartz: Starting X server: %s --listenonly",
g5:/opt/local/var/macports/build/xorg-server-1.18-583abf22/work alex$ 
```
So apparently Xquartz binary doesn't use the above stub code. In any case, one could symlink /Applications/MacPorts/X11.app/Contents/MacOS/X11.bin to /opt/local/bin/X and have startx work, but I'm not doing that here unless you think it makes sense.

