### PR TITLE
cairo: remove hack, proper quartz support on tiger

### DIFF
--- a/graphics/cairo/Portfile
+++ b/graphics/cairo/Portfile
@@ -115,12 +115,15 @@ platform macosx {
                             -Dquartz=disabled -Dquartz=enabled
     }
 
-    if {${os.major} > 8} {
-        default_variants        +quartz
-        # Don't allow Quartz support to be disabled. Keep the variant for awhile in
-        # case any dependents are using the active_variants portgroup to check for it.
-        variant_set             quartz
-    }
+    default_variants        +quartz
+    # Don't allow Quartz support to be disabled. Keep the variant for awhile in
+    # case any dependents are using the active_variants portgroup to check for it.
+    variant_set             quartz
+}
+
+# 10.4 has different API.
+platform darwin 8 {
+    patchfiles-append    quartz-tiger.diff
 }
 
 variant x11 {

--- a/graphics/cairo/files/quartz-tiger.diff
+++ b/graphics/cairo/files/quartz-tiger.diff
@@ -1,0 +1,110 @@
+--- a/src/cairo-quartz-image-surface.c.orig	2026-09-13 01:17:01.000000000 -0600
++++ b/src/cairo-quartz-image-surface.c	2026-09-13 01:41:35.000000000 -0600
+@@ -307,7 +307,11 @@
+ 	colorspace = _cairo_quartz_create_color_space (context);
+     }
+     else {
+-	colorspace = CGDisplayCopyColorSpace (CGMainDisplayID ());
++    #if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
++       colorspace = CGDisplayCopyColorSpace (CGMainDisplayID ());
++    #else
++       colorspace = CGColorSpaceCreateDeviceRGB ();
++    #endif
+     }
+ 
+     bitinfo |= format == CAIRO_FORMAT_ARGB32 ? kCGImageAlphaPremultipliedFirst : kCGImageAlphaNoneSkipFirst;
+--- a/src/cairo-quartz-surface.c.orig	2026-09-12 23:32:52.000000000 -0600
++++ b/src/cairo-quartz-surface.c	2026-09-13 01:34:53.000000000 -0600
+@@ -200,8 +200,10 @@
+         if (color_space)
+             return color_space;
+     }
++    #if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
+     if (!color_space)
+         color_space =  CGDisplayCopyColorSpace (CGMainDisplayID ());
++    #endif
+ 
+     if (!color_space)
+         color_space = CGColorSpaceCreateDeviceRGB ();
+@@ -344,6 +346,48 @@
+  * Misc helpers/callbacks
+  */
+ 
++#if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++typedef enum {
++    kPrivateCGCompositeClear = 0,
++    kPrivateCGCompositeCopy = 1,
++    kPrivateCGCompositeSourceOver = 2,
++    kPrivateCGCompositeSourceIn = 3,
++    kPrivateCGCompositeSourceOut = 4,
++    kPrivateCGCompositeSourceAtop = 5,
++    kPrivateCGCompositeDestinationOver = 6,
++    kPrivateCGCompositeDestinationIn = 7,
++    kPrivateCGCompositeDestinationOut = 8,
++    kPrivateCGCompositeDestinationAtop = 9,
++    kPrivateCGCompositeXOR = 10,
++    kPrivateCGCompositePlusDarker = 11,
++    kPrivateCGCompositePlusLighter = 12
++} PrivateCGCompositeMode;
++
++CG_EXTERN void CGContextSetCompositeOperation (
++    CGContextRef context,
++    PrivateCGCompositeMode mode);
++
++static PrivateCGCompositeMode
++_cairo_quartz_cairo_operator_to_quartz_composite (cairo_operator_t op)
++{
++    switch (op) {
++    case CAIRO_OPERATOR_CLEAR:       return kPrivateCGCompositeClear;
++    case CAIRO_OPERATOR_SOURCE:      return kPrivateCGCompositeCopy;
++    case CAIRO_OPERATOR_OVER:        return kPrivateCGCompositeSourceOver;
++    case CAIRO_OPERATOR_IN:          return kPrivateCGCompositeSourceIn;
++    case CAIRO_OPERATOR_OUT:         return kPrivateCGCompositeSourceOut;
++    case CAIRO_OPERATOR_ATOP:        return kPrivateCGCompositeSourceAtop;
++    case CAIRO_OPERATOR_DEST_OVER:   return kPrivateCGCompositeDestinationOver;
++    case CAIRO_OPERATOR_DEST_IN:     return kPrivateCGCompositeDestinationIn;
++    case CAIRO_OPERATOR_DEST_OUT:    return kPrivateCGCompositeDestinationOut;
++    case CAIRO_OPERATOR_DEST_ATOP:   return kPrivateCGCompositeDestinationAtop;
++    case CAIRO_OPERATOR_XOR:         return kPrivateCGCompositeXOR;
++    case CAIRO_OPERATOR_ADD:         return kPrivateCGCompositePlusLighter;
++    default:
++        ASSERT_NOT_REACHED;
++    }
++}
++#endif
+ 
+ static CGBlendMode
+ _cairo_quartz_cairo_operator_to_quartz_blend (cairo_operator_t op)
+@@ -379,7 +423,7 @@
+ 	    return kCGBlendModeColor;
+ 	case CAIRO_OPERATOR_HSL_LUMINOSITY:
+ 	    return kCGBlendModeLuminosity;
+-
++#if MAC_OS_X_VERSION_MIN_REQUIRED > 1040
+ 	case CAIRO_OPERATOR_CLEAR:
+ 	    return kCGBlendModeClear;
+ 	case CAIRO_OPERATOR_SOURCE:
+@@ -404,6 +448,7 @@
+ 	    return kCGBlendModeXOR;
+ 	case CAIRO_OPERATOR_ADD:
+ 	    return kCGBlendModePlusLighter;
++#endif
+ 	case CAIRO_OPERATOR_DEST:
+ 	case CAIRO_OPERATOR_SATURATE:
+         default:
+@@ -433,6 +478,15 @@
+ 	return CAIRO_INT_STATUS_UNSUPPORTED;
+     }
+ 
++    #if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
++        if (op <= CAIRO_OPERATOR_ADD) {
++            PrivateCGCompositeMode composite;
++
++            composite = _cairo_quartz_cairo_operator_to_quartz_composite (op);
++            CGContextSetCompositeOperation (context, composite);
++            return CAIRO_STATUS_SUCCESS;
++        }
++    #endif
+     blendmode = _cairo_quartz_cairo_operator_to_quartz_blend (op);
+     CGContextSetBlendMode (context, blendmode);
+     return CAIRO_STATUS_SUCCESS;


### PR DESCRIPTION
cairo has a long history of getting back 10.4 support then dropping it: https://cairo.freedesktop.org/news/cairo-1.16.0/
so upstream should be supportive if they know there are users as they last supported it in 2018. I used old cairo versions to base this off of. Basically 10.4 API is different then 10.5+ as per usual.

This gets us back to proper variant quartz+x11 like macports upstream on all platforms including darwin 8. This also fixes py-cairo+x11+xquartz issue.